### PR TITLE
e2e: add workflow for pushing major tag

### DIFF
--- a/.github/workflows/e2e.go.major.tag.main.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.major.tag.main.config-ldflags-assets.slsa3.yml
@@ -1,0 +1,138 @@
+# Creates a new release on vX and vX.Y tag push for verifier testing.
+
+name: go tag main SLSA3 config-ldflags assets
+
+on: 
+  workflow_dispatch:
+  push:
+    tags:
+      - "v[0-9]+" # Matches major versions like v10
+      - "v[0-9]+.[0-9]+" # Matches versions like v10.0
+
+permissions: read-all
+
+env:
+  GH_TOKEN: ${{ secrets.E2E_GO_TOKEN }}
+  ISSUE_REPOSITORY: slsa-framework/slsa-github-generator
+  #ISSUE_REPOSITORY: laurentsimon/slsa-on-github-test
+  # WARNING: update build job if CONFIG_FILE changes.
+  CONFIG_FILE: .github/configs-go/config-ldflags.yml
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - id: create
+        run: |
+          set -euo pipefail
+
+          # Note: we use v13.x.y
+          ./.github/workflows/scripts/e2e-create-release.sh
+
+  shim: 
+    needs: [release]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    outputs:
+      continue: ${{ steps.verify.outputs.continue }}
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - id: verify
+        run: |
+          set -euo pipefail
+
+          ./.github/workflows/scripts/e2e-verify-release.sh
+
+  args:
+    needs: [shim]
+    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ldflags.outputs.version }}
+      commit: ${{ steps.ldflags.outputs.commit }}
+      branch: ${{ steps.ldflags.outputs.branch }}
+    steps:
+      - id: checkout
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.3.4
+        with:
+          fetch-depth: 0
+      - id: ldflags
+        run: |
+          set -euo pipefail
+          
+          THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
+          BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
+          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
+          echo "::set-output name=commit::-X main.gitCommit=abcdef"
+          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+
+  build:
+    needs: [shim,args]
+    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
+    permissions:
+      id-token: write # For signing.
+      contents: write # For asset uploads.
+      actions: read # For the entrypoint.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@main
+    with:
+      go-version: 1.18
+      # We cannot use ${{ env.CONFIG_FILE }} because env variables are not available.
+      config-file: .github/configs-go/config-ldflags.yml
+      evaluated-envs: "VERSION:${{needs.args.outputs.version}},COMMIT:${{needs.args.outputs.commit}},BRANCH:${{needs.args.outputs.branch}}"
+      compile-builder: true
+  
+  # build:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - run: |
+  #         echo hello
+  #         #exit 1
+    
+  verify:
+    runs-on: ubuntu-latest
+    needs: [shim,build]
+    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          name: ${{ needs.build.outputs.go-binary-name }}
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
+      - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
+        with:
+          go-version: '1.17'
+      - env:
+          BINARY: ${{ needs.build.outputs.go-binary-name }}
+          PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
+        run: |
+          set -euo pipefail
+          
+          ./.github/workflows/scripts/e2e-verify.sh
+
+  if-succeeded:
+    runs-on: ubuntu-latest
+    needs: [shim,build,verify]
+    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && needs.build.result == 'success' && needs.verify.result == 'success'
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - run: |
+          set -euo pipefail
+
+          ./.github/workflows/scripts/e2e-report-success.sh
+
+  if-failed:
+    runs-on: ubuntu-latest
+    needs: [shim,build,verify]
+    if: always() && needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && (needs.build.result == 'failure' || needs.verify.result == 'failure')
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - run: |
+          set -euo pipefail
+
+          ./.github/workflows/scripts/e2e-report-failure.sh


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

On major tag push, create release, then create provenance

For adding to slsa-verifier tests. Will add RELEASE.md docs on using this workflow in slsa-verifier repo.