### PR TITLE
remove -z option from grep

### DIFF
--- a/.github/workflows/scripts/e2e.go.default.verify.sh
+++ b/.github/workflows/scripts/e2e.go.default.verify.sh
@@ -96,7 +96,7 @@ verify_provenance_content() {
             e2e_assert_eq "$BINARY" "binary-linux-amd64-unknown"
         else
             ./"$BINARY"
-            T=$(./"$BINARY" | grep -zoP "GitTag: \n")
+            T=$(./"$BINARY" | grep -oP "GitTag: \n")
             e2e_assert_not_eq "$T" "" "GitTag should be empty"
 
             e2e_assert_eq "$BINARY" "binary-linux-amd64"


### PR DESCRIPTION
@laurentsimon Why was `-z` used here? it produces a warning like `-bash: warning: command substitution: ignored null byte in input` and I couldn't see a reason why it would be used.