### PR TITLE
compile-builder in invalidpath test

### DIFF
--- a/.github/workflows/e2e.go.schedule.main.adversarial-invalidpath.yml
+++ b/.github/workflows/e2e.go.schedule.main.adversarial-invalidpath.yml
@@ -1,6 +1,6 @@
-on: 
+on:
   schedule:
-    - cron: '0 10 * * *'
+    - cron: "0 10 * * *"
   workflow_dispatch:
 
 permissions: read-all
@@ -8,11 +8,11 @@ permissions: read-all
 env:
   GH_TOKEN: ${{ secrets.E2E_GO_TOKEN }}
   ISSUE_REPOSITORY: slsa-framework/slsa-github-generator
-  #ISSUE_REPOSITORY: laurentsimon/slsa-on-github-test
+  # ISSUE_REPOSITORY: laurentsimon/slsa-on-github-test
   # WARNING: update build job if CONFIG_FILE changes.
   CONFIG_FILE: ../invalid/path.yml
 
-jobs:            
+jobs:
   build:
     permissions:
       id-token: write # For signing.
@@ -23,31 +23,31 @@ jobs:
       go-version: 1.18
       # We cannot use ${{ env.CONFIG_FILE }} because env variables are not available.
       config-file: ../invalid/path.yml
-  
-#   build:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - run: |
-#           exit 1
+      compile-builder: true
+
+  #   build:
+  #     runs-on: ubuntu-latest
+  #     steps:
+  #       - run: |
+  #           exit 1
 
   if-succeeded:
     runs-on: ubuntu-latest
     needs: [build]
     if: needs.build.result == 'success'
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: |
           set -euo pipefail
 
           ./.github/workflows/scripts/e2e-report-failure.sh
-
 
   if-failed:
     runs-on: ubuntu-latest
     needs: [build]
     if: always() && needs.build.result == 'failure'
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: |
           set -euo pipefail
 


### PR DESCRIPTION
`compile-builder` needs to be true otherwise the workflow will fail with an "Invalid ref" error for being run from the main branch and potentially mask problems with the config-file path handling.

We want it to fail for the right reasons.