### PR TITLE
Update release creation script

### DIFF
--- a/.github/workflows/scripts/e2e-create-release.sh
+++ b/.github/workflows/scripts/e2e-create-release.sh
@@ -4,61 +4,61 @@ set -euo pipefail
 # shellcheck source=/dev/null
 source "./.github/workflows/scripts/e2e-utils.sh"
 
-THIS_FILE=$(e2e_this_file)
-echo "THIS_FILE: $THIS_FILE"
+this_file=$(e2e_this_file)
+echo "THIS_FILE: $this_file"
 
 # Use the PAT_TOKEN if one is specified.
 # TODO(github.com/slsa-framework/example-package/issues/52): Always use PAT_TOKEN
-TOKEN=$PAT_TOKEN
-if [[ -z "$TOKEN" ]]; then
-    TOKEN=$GH_TOKEN
+token=$PAT_TOKEN
+if [[ -z "$token" ]]; then
+    token=$GH_TOKEN
 fi
 
 # List the releases and find the latest for THIS_FILE.
-DEFAULT_MAJOR=$(version_major "$DEFAULT_VERSION")
-if [[ -z "$DEFAULT_MAJOR" ]]; then
+default_major=$(version_major "$DEFAULT_VERSION")
+if [[ -z "$default_major" ]]; then
     echo "Invalid DEFAULT_VERSION: $DEFAULT_VERSION"
     exit 1
 fi
 
 # Here we find the latest version with the major version equal to that of
 # DEFAULT_VERSION.
-RELEASE_LIST=$(gh release -L 200 list)
-LATEST_TAG=$DEFAULT_VERSION
+release_list=$(gh release -L 200 list)
+latest_tag=$DEFAULT_VERSION
 while read -r line; do
-    TAG=$(echo "$line" | cut -f1)
-    MAJOR=$(version_major "$TAG")
-    if [ "$MAJOR" == "$DEFAULT_MAJOR" ]; then
-        echo "  Processing $TAG"
-        echo "  LATEST_TAG: $LATEST_TAG"
-        if version_gt "$TAG" "$LATEST_TAG"; then
-            echo " INFO: updating to $TAG"
-            LATEST_TAG="$TAG"
+    tag=$(echo "$line" | cut -f1)
+    major=$(version_major "$tag")
+    if [ "$major" == "$default_major" ]; then
+        echo "  Processing $tag"
+        echo "  latest_tag: $latest_tag"
+        if version_gt "$TAG" "$latest_tag"; then
+            echo " INFO: updating to $tag"
+            latest_tag="$tag"
         fi
     fi
-done <<<"$RELEASE_LIST"
+done <<<"$release_list"
 
-echo "Latest tag found is $LATEST_TAG"
+echo "Latest tag found is $latest_tag"
 
-RELEASE_MAJOR=$(version_major "$LATEST_TAG")
-RELEASE_MINOR=$(version_minor "$LATEST_TAG")
-RELEASE_PATCH=$(version_patch "$LATEST_TAG")
-NEW_PATCH=$((${RELEASE_PATCH:-0} + 1))
-TAG="${RELEASE_MAJOR:-$DEFAULT_MAJOR}.${RELEASE_MINOR:-0}.$NEW_PATCH"
+release_major=$(version_major "$latest_tag")
+release_minor=$(version_minor "$latest_tag")
+release_patch=$(version_patch "$latest_tag")
+new_patch=$((${release_patch:-0} + 1))
+tag="${release_major:-$default_major}.${release_minor:-0}.$new_patch"
 
-BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
+branch=$(echo "$this_file" | cut -d '.' -f4)
 
-echo "New release tag used: $TAG"
-echo "Target branch: $BRANCH"
+echo "New release tag used: $tag"
+echo "Target branch: $branch"
 
 cat <<EOF >DATA
 **E2E release creation**:
-Tag: $TAG
-Branch: $BRANCH
+Tag: $tag
+Branch: $branch
 Commit: $GITHUB_SHA
-Caller file: $THIS_FILE
+Caller file: $this_file
 EOF
 
 # We must use a PAT here in order to trigger subsequent workflows.
 # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854
-GH_TOKEN=$TOKEN gh release create "$TAG" --notes-file ./DATA --target "$BRANCH"
+GH_TOKEN=$token gh release create "$tag" --notes-file ./DATA --target "$branch"

--- a/.github/workflows/scripts/e2e-create-release.sh
+++ b/.github/workflows/scripts/e2e-create-release.sh
@@ -21,28 +21,28 @@ if [[ -z "$DEFAULT_MAJOR" ]]; then
     exit 1
 fi
 
-# Here we find the highest version with the major version equal to that of
+# Here we find the latest version with the major version equal to that of
 # DEFAULT_VERSION.
 RELEASE_LIST=$(gh release -L 200 list)
-HIGHEST_TAG=$DEFAULT_VERSION
+LATEST_TAG=$DEFAULT_VERSION
 while read -r line; do
     TAG=$(echo "$line" | cut -f1)
     MAJOR=$(version_major "$TAG")
     if [ "$MAJOR" == "$DEFAULT_MAJOR" ]; then
         echo "  Processing $TAG"
-        echo "  HIGHEST_TAG: $HIGHEST_TAG"
-        if version_gt "$TAG" "$HIGHEST_TAG"; then
+        echo "  LATEST_TAG: $LATEST_TAG"
+        if version_gt "$TAG" "$LATEST_TAG"; then
             echo " INFO: updating to $TAG"
-            HIGHEST_TAG="$TAG"
+            LATEST_TAG="$TAG"
         fi
     fi
 done <<<"$RELEASE_LIST"
 
-echo "Latest tag found is $RELEASE_TAG"
+echo "Latest tag found is $LATEST_TAG"
 
-RELEASE_MAJOR=$(version_major "$RELEASE_TAG")
-RELEASE_MINOR=$(version_minor "$RELEASE_TAG")
-RELEASE_PATCH=$(version_patch "$RELEASE_TAG")
+RELEASE_MAJOR=$(version_major "$LATEST_TAG")
+RELEASE_MINOR=$(version_minor "$LATEST_TAG")
+RELEASE_PATCH=$(version_patch "$LATEST_TAG")
 NEW_PATCH=$((${RELEASE_PATCH:-0} + 1))
 TAG="${RELEASE_MAJOR:-$DEFAULT_MAJOR}.${RELEASE_MINOR:-0}.$NEW_PATCH"
 

--- a/.github/workflows/scripts/e2e-create-release.sh
+++ b/.github/workflows/scripts/e2e-create-release.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 # shellcheck source=/dev/null
 source "./.github/workflows/scripts/e2e-utils.sh"
 
-RELEASE_TAG=""
-
 THIS_FILE=$(e2e_this_file)
 echo "THIS_FILE: $THIS_FILE"
 
@@ -18,35 +16,27 @@ fi
 
 # List the releases and find the latest for THIS_FILE.
 DEFAULT_MAJOR=$(version_major "$DEFAULT_VERSION")
+if [[ -z "$DEFAULT_MAJOR" ]]; then
+    echo "Invalid DEFAULT_VERSION: $DEFAULT_VERSION"
+    exit 1
+fi
+
+# Here we find the highest version with the major version equal to that of
+# DEFAULT_VERSION.
 RELEASE_LIST=$(gh release -L 200 list)
-HIGHEST_PATCH="0"
+HIGHEST_TAG=$DEFAULT_VERSION
 while read -r line; do
     TAG=$(echo "$line" | cut -f1)
     MAJOR=$(version_major "$TAG")
     if [ "$MAJOR" == "$DEFAULT_MAJOR" ]; then
-        # We only bump the patch, so we need not verify major/minor.
-        PATCH=$(version_patch "$TAG")
-        if [ "$PATCH" == "" ]; then
-            echo "invalid patch version for $TAG"
-            continue
-        fi
         echo "  Processing $TAG"
-        echo "  PATCH: $PATCH"
-        echo "  HIGEST_PATCH: $HIGHEST_PATCH"
-        echo "  RELEASE_TAG: $RELEASE_TAG"
-        if [[ "$PATCH" -gt "$HIGHEST_PATCH" ]]; then
+        echo "  HIGHEST_TAG: $HIGHEST_TAG"
+        if version_gt "$TAG" "$HIGHEST_TAG"; then
             echo " INFO: updating to $TAG"
-            PATCH="$P"
-            RELEASE_TAG="$TAG"
+            HIGHEST_TAG="$TAG"
         fi
     fi
 done <<<"$RELEASE_LIST"
-
-if [[ -z "$RELEASE_TAG" ]]; then
-    echo "Tag not found for $THIS_FILE"
-    echo "Defaulting to DEFAULT_VERSION: $DEFAULT_VERSION"
-    RELEASE_TAG="$DEFAULT_VERSION"
-fi
 
 echo "Latest tag found is $RELEASE_TAG"
 
@@ -54,17 +44,15 @@ RELEASE_MAJOR=$(version_major "$RELEASE_TAG")
 RELEASE_MINOR=$(version_minor "$RELEASE_TAG")
 RELEASE_PATCH=$(version_patch "$RELEASE_TAG")
 NEW_PATCH=$((${RELEASE_PATCH:-0} + 1))
-NEW_RELEASE_TAG="${RELEASE_MAJOR:-$DEFAULT_MAJOR}.${RELEASE_MINOR:-0}.$NEW_PATCH"
+TAG="${RELEASE_MAJOR:-$DEFAULT_MAJOR}.${RELEASE_MINOR:-0}.$NEW_PATCH"
 
 BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-
-TAG="$NEW_RELEASE_TAG"
 
 echo "New release tag used: $TAG"
 echo "Target branch: $BRANCH"
 
 cat <<EOF >DATA
-**E2e release creation**:
+**E2E release creation**:
 Tag: $TAG
 Branch: $BRANCH
 Commit: $GITHUB_SHA


### PR DESCRIPTION
Updates the release creation script to use the major version from `DEFAULT_VERSION` defined in each e2e test workflow.

Instead of checking the body of each release for the file name, we check the major version of the release against the major version of `DEFAULT_VERSION`. This allows us to skip making an API call to get the release body and save us a lot of API calls that are made against the PAT quota.

Also updated the script to use the common semver parsing functions.