### PR TITLE
Check provenance job result

### DIFF
--- a/.github/workflows/e2e.generic.release.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.release.main.default.slsa3.yml
@@ -107,16 +107,16 @@ jobs:
 
   if-succeeded:
     runs-on: ubuntu-latest
-    needs: [shim, build, verify]
-    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag' && needs.build.result == 'success' && needs.verify.result == 'success'
+    needs: [shim, build, provenance, verify]
+    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag' && needs.build.result == 'success' && needs.provenance.result == 'success' && needs.verify.result == 'success'
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: ./.github/workflows/scripts/e2e-report-success.sh
 
   if-failed:
     runs-on: ubuntu-latest
-    needs: [shim, build, verify]
-    if: always() && needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag' && (needs.build.result == 'failure' || needs.verify.result == 'failure')
+    needs: [shim, build, provenance, verify]
+    if: always() && needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag' && (needs.build.result == 'failure' || needs.provenance.result == 'failure' || needs.verify.result == 'failure')
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: ./.github/workflows/scripts/e2e-report-failure.sh

--- a/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
@@ -83,7 +83,7 @@ jobs:
   if-succeeded:
     runs-on: ubuntu-latest
     needs: [build, provenance, verify]
-    if: needs.build.result == 'success' && needs.verify.result == 'success'
+    if: needs.build.result == 'success' && needs.provenance.result == 'success' && needs.verify.result == 'success'
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: ./.github/workflows/scripts/e2e-report-success.sh
@@ -91,7 +91,7 @@ jobs:
   if-failed:
     runs-on: ubuntu-latest
     needs: [build, provenance, verify]
-    if: always() && (needs.build.result == 'failure' || needs.verify.result == 'failure')
+    if: always() && (needs.build.result == 'failure' || needs.provenance.result == 'failure' || needs.verify.result == 'failure')
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: ./.github/workflows/scripts/e2e-report-failure.sh

--- a/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
@@ -109,16 +109,16 @@ jobs:
 
   if-succeeded:
     runs-on: ubuntu-latest
-    needs: [shim, build, verify]
-    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && needs.build.result == 'success' && needs.verify.result == 'success'
+    needs: [shim, build, provenance, verify]
+    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && needs.build.result == 'success' && needs.provenance.result == 'success' && needs.verify.result == 'success'
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: ./.github/workflows/scripts/e2e-report-success.sh
 
   if-failed:
     runs-on: ubuntu-latest
-    needs: [shim, build, verify]
-    if: always() && needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && (needs.build.result == 'failure' || needs.verify.result == 'failure')
+    needs: [shim, build, provenance, verify]
+    if: always() && needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && (needs.build.result == 'failure' || needs.provenance.result == 'failure' || needs.verify.result == 'failure')
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: ./.github/workflows/scripts/e2e-report-failure.sh

--- a/.github/workflows/e2e.generic.tag.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.default.slsa3.yml
@@ -105,16 +105,16 @@ jobs:
 
   if-succeeded:
     runs-on: ubuntu-latest
-    needs: [shim, build, verify]
-    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && needs.build.result == 'success' && needs.verify.result == 'success'
+    needs: [shim, build, provenance, verify]
+    if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && needs.build.result == 'success' && needs.provenance.result == 'success' && needs.verify.result == 'success'
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: ./.github/workflows/scripts/e2e-report-success.sh
 
   if-failed:
     runs-on: ubuntu-latest
-    needs: [shim, build, verify]
-    if: always() && needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && (needs.build.result == 'failure' || needs.verify.result == 'failure')
+    needs: [shim, build, provenance, verify]
+    if: always() && needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag' && (needs.build.result == 'failure' || needs.provenance.result == 'failure' || needs.verify.result == 'failure')
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: ./.github/workflows/scripts/e2e-report-failure.sh


### PR DESCRIPTION
[this e2e test run](https://github.com/slsa-framework/example-package/actions/runs/2607555368) did not create a bug because the provenance job was not checked at the end.

This PR adds checks for the `provenance` job in generic e2e test workflows.