### PR TITLE
feat: only test max patch verifier versions

### DIFF
--- a/.github/workflows/scripts/e2e-verify.common.sh
+++ b/.github/workflows/scripts/e2e-verify.common.sh
@@ -257,6 +257,15 @@ e2e_run_verifier_all_releases() {
             continue
         fi
 
+        # Check if a greater patch version exists
+        MAJOR=$(version_major "$TAG")
+        MINOR=$(version_minor "$TAG")
+        PATCH=$(version_patch "$TAG")
+        PATCH_PLUS_ONE=$((${PATCH:-0} + 1))
+        if grep -q "v$MAJOR.$MINOR.$PATCH_PLUS_ONE" <<< "$RELEASE_LIST"; then
+            continue
+        fi
+
         echo "  *** Starting with verifier at $TAG ****"
 
         # Always remove the binary, because `gh release download` fails if the file already exists.


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This prevents using broken minor patch versions of the verifier.

only merge pending https://github.com/slsa-framework/slsa-verifier/pull/143