### PR TITLE
chore: update go version

### DIFF
--- a/.github/workflows/e2e.generic.release.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.release.main.default.slsa3.yml
@@ -99,7 +99,7 @@ jobs:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - env:
           BINARY: ${{ needs.build.outputs.binary-name }}
           PROVENANCE: ${{ needs.provenance.outputs.attestation-name }}

--- a/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - name: Verify provenance
         env:
           BINARY: ${{ needs.build.outputs.binary-name }}

--- a/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
@@ -101,7 +101,7 @@ jobs:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - env:
           BINARY: ${{ needs.build.outputs.binary-name }}
           PROVENANCE: ${{ needs.provenance.outputs.attestation-name }}

--- a/.github/workflows/e2e.generic.tag.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.default.slsa3.yml
@@ -98,7 +98,7 @@ jobs:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - env:
           BINARY: ${{ needs.build.outputs.binary-name }}
           PROVENANCE: ${{ needs.provenance.outputs.attestation-name }}

--- a/.github/workflows/e2e.go.push.branch1.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.branch1.config-ldflags.slsa3.yml
@@ -103,7 +103,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.push.main.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.main.config-ldflags.slsa3.yml
@@ -85,7 +85,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.push.main.config-noldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.main.config-noldflags.slsa3.yml
@@ -62,7 +62,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.release.main.config-ldflags-assets-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-assets-tag.slsa3.yml
@@ -101,7 +101,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.release.main.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-assets.slsa3.yml
@@ -101,7 +101,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.release.main.config-ldflags-noassets.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-noassets.slsa3.yml
@@ -101,7 +101,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.schedule.main.config-ldflags-main-dir.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-ldflags-main-dir.slsa3.yml
@@ -72,7 +72,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.schedule.main.config-ldflags-main.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-ldflags-main.slsa3.yml
@@ -71,7 +71,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.schedule.main.config-noldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-noldflags.slsa3.yml
@@ -45,7 +45,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.tag.branch1.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.branch1.config-ldflags-assets.slsa3.yml
@@ -101,7 +101,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-tag.slsa3.yml
@@ -102,7 +102,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets.slsa3.yml
@@ -102,7 +102,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-noassets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-noassets.slsa3.yml
@@ -103,7 +103,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
@@ -99,7 +99,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl

--- a/.github/workflows/e2e.go.workflow_dispatch.main.config-noldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.main.config-noldflags.slsa3.yml
@@ -57,7 +57,7 @@ jobs:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - env:
           BINARY: ${{ needs.build.outputs.go-binary-name }}
           PROVENANCE: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

slsa-verifier requires 1.18:
```
go: downloading github.com/modern-go/reflect2 v1.0.2
go: downloading k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf
# sigs.k8s.io/release-utils/version
Error: ../../../go/pkg/mod/sigs.k8s.io/release-utils@v0.7.1/version/version.go:124:25: bi.Settings undefined (type *debug.BuildInfo has no field or method Settings)
note: module requires Go 1.18
```

see https://github.com/slsa-framework/example-package/runs/7306391193?check_suite_focus=true
