### PR TITLE
fix: fix permissions on dispatch job

### DIFF
--- a/.github/workflows/e2e.container.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.default.slsa3.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0

--- a/.github/workflows/e2e.container.workflow_dispatch.main.workflow_inputs.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.workflow_inputs.slsa3.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0

--- a/.github/workflows/e2e.gcb.workflow_dispatch.main.cloudbuild.slsa3.yml
+++ b/.github/workflows/e2e.gcb.workflow_dispatch.main.cloudbuild.slsa3.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' && github.event.schedule == '0 3 1,15 * *'
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0

--- a/.github/workflows/e2e.gcb.workflow_dispatch.main.dockerfile.slsa3.yml
+++ b/.github/workflows/e2e.gcb.workflow_dispatch.main.dockerfile.slsa3.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' && github.event.schedule == '0 3 1,15 * *'
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0

--- a/.github/workflows/e2e.gcb.workflow_dispatch.main.dockerfile.slsa3.yml
+++ b/.github/workflows/e2e.gcb.workflow_dispatch.main.dockerfile.slsa3.yml
@@ -58,7 +58,7 @@ jobs:
           gcloud builds submit --region=us-west2 --project slsa-tooling --suppress-logs --tag ${IMAGE_REGISTRY}/${IMAGE_PROJECT}/${IMAGE_NAME} --gcs-log-dir:gs://slsa-tooling_coudbuild/
 
           # Retrieve the latest build ID
-          # TODO: How do we avoid races? Can we directly get the output of builds submit? 
+          # TODO: How do we avoid races? Can we directly get the output of builds submit?
           export BUILD_ID=$(gcloud builds --verbosity debug list --region=us-west2 --project slsa-tooling --limit=1 --format="value(id)")
           echo "Created build with build id ${BUILD_ID}..."
 

--- a/.github/workflows/e2e.generic.workflow_dispatch.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.branch1.default.slsa3.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.default.slsa3.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.workflow_inputs.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.workflow_inputs.slsa3.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0

--- a/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
@@ -14,6 +14,9 @@ env:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      content: write
     # WARNING: need `github.ref_name == 'main'` to avoid infinite loop when triggering manually.
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref_name == 'main')
     steps:

--- a/.github/workflows/e2e.go.workflow_dispatch.main.config-noldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.main.config-noldflags.slsa3.yml
@@ -15,6 +15,9 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
+    permissions:
+      actions: write
+      content: write
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0
       - run: ./.github/workflows/scripts/e2e-dispatch.sh

--- a/.github/workflows/e2e.go.workflow_dispatch.main.workflow_inputs.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.main.workflow_inputs.slsa3.yml
@@ -20,6 +20,9 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
+    permissions:
+      actions: write
+      content: write
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0
       - run: |


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/slsa-framework/example-package/issues/110

Adds actions write perms to the dispatch job so it can trigger a workflow run:
https://docs.github.com/rest/reference/actions#create-a-workflow-dispatch-event