### PR TITLE
Add e2e test for slsa-verifier installer.

### DIFF
--- a/.github/workflows/e2e.installer-action.yml
+++ b/.github/workflows/e2e.installer-action.yml
@@ -1,0 +1,18 @@
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  test-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slsa-framework/slsa-verifier/actions/installer@v1.4.0
+      - uses: slsa-framework/slsa-verifier/actions/installer@v1.4.1
+  test-hashes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slsa-framework/slsa-verifier/actions/installer@936dc46aca3ed973d542a09d2a9d890705ce5011
+      - uses: slsa-framework/slsa-verifier/actions/installer@e6428d7da594455a4c2b7f24907fec421a5e0e95

--- a/.github/workflows/e2e.installer-action.yml
+++ b/.github/workflows/e2e.installer-action.yml
@@ -1,6 +1,4 @@
 on:
-  schedule:
-    - cron: "0 5 * * *"
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/verifier-e2e.generic.workflow_dispatch.main.all.slsa3.yml
+++ b/.github/workflows/verifier-e2e.generic.workflow_dispatch.main.all.slsa3.yml
@@ -1,6 +1,6 @@
 # This produces a test for the generic workflows for the CLI e2e test.
 # The output will be a file binary-linux-amd64-workflow_dispatch and
-# its associated provenance that should be moved to the 
+# its associated provenance that should be moved to the
 # cli/slsa-verifier/testdata/gha_generic/$BUILDER_TAG folder.
 
 on:
@@ -24,7 +24,7 @@ jobs:
       binary-name: ${{ steps.create_name.outputs.binary-name }}
     runs-on: ubuntu-latest
     steps:
-      - name: Creates the output name 
+      - name: Creates the output name
         id: create_name
         run: |
           if [ ${{ github.event_name == 'workflow_dispatch' }} ]; then

--- a/.github/workflows/verifier-e2e.go.workflow_dispatch.main.all.slsa3.yml
+++ b/.github/workflows/verifier-e2e.go.workflow_dispatch.main.all.slsa3.yml
@@ -1,6 +1,6 @@
 # This produces a test for the generic workflows for the CLI e2e test.
 # The output will be a file binary-linux-amd64-workflow_dispatch and
-# its associated provenance that should be moved to the 
+# its associated provenance that should be moved to the
 # cli/slsa-verifier/testdata/gha_generic/$BUILDER_TAG folder.
 
 on:
@@ -24,7 +24,7 @@ jobs:
       binary-name: ${{ steps.create_name.outputs.binary-name }}
     runs-on: ubuntu-latest
     steps:
-      - name: Creates the output name 
+      - name: Creates the output name
         id: create_name
         run: |
           if [ ${{ github.event_name == 'workflow_dispatch' }} ]; then


### PR DESCRIPTION
I couldn't find a way to use a matrix to pin the action version, so I've written out releases manually for now.