### PR TITLE
Bump go version in `WORKSPACE` file.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,6 @@ go_dependencies()
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.19")
+go_register_toolchains(version = "1.20")
 
 gazelle_dependencies()


### PR DESCRIPTION
This is to enable merging Dependabot created #141. We need to merge both of these on the same day to ensure that the bazel build does not break.

Unfortunately, Dependabot does not know to update this at the same time as creating #141 (and similar).

See also #128 which was needed to fix the builds when #121 landed.