### PR TITLE
Replace GitHub set-output commands

### DIFF
--- a/.github/workflows/e2e.container.push.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.container.push.branch1.default.slsa3.yml
@@ -50,7 +50,7 @@ jobs:
 
           BRANCH=$(e2e_this_branch)
           if [[ "$BRANCH" == "$GITHUB_REF_NAME" ]]; then
-            echo "::set-output name=continue::yes"
+            echo "continue=yes" >> $GITHUB_OUTPUT
           fi
 
   # Build the Go application into a Docker image
@@ -101,7 +101,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.push.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.container.push.branch1.default.slsa3.yml
@@ -50,7 +50,7 @@ jobs:
 
           BRANCH=$(e2e_this_branch)
           if [[ "$BRANCH" == "$GITHUB_REF_NAME" ]]; then
-            echo "continue=yes" >> $GITHUB_OUTPUT
+            echo "continue=yes" >> "${GITHUB_OUTPUT}"
           fi
 
   # Build the Go application into a Docker image
@@ -101,7 +101,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container.push.main.default.slsa3.yml
@@ -82,7 +82,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container.push.main.default.slsa3.yml
@@ -82,7 +82,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.schedule.main.continue-on-error.slsa3.yml
+++ b/.github/workflows/e2e.container.schedule.main.continue-on-error.slsa3.yml
@@ -66,7 +66,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.schedule.main.continue-on-error.slsa3.yml
+++ b/.github/workflows/e2e.container.schedule.main.continue-on-error.slsa3.yml
@@ -66,7 +66,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.schedule.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container.schedule.main.default.slsa3.yml
@@ -70,7 +70,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.schedule.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container.schedule.main.default.slsa3.yml
@@ -70,7 +70,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.tag.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.container.tag.branch1.default.slsa3.yml
@@ -92,7 +92,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.tag.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.container.tag.branch1.default.slsa3.yml
@@ -92,7 +92,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.tag.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container.tag.main.default.slsa3.yml
@@ -96,7 +96,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.tag.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container.tag.main.default.slsa3.yml
@@ -96,7 +96,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.tag.main.gcp-workload-identity.slsa3.yml
+++ b/.github/workflows/e2e.container.tag.main.gcp-workload-identity.slsa3.yml
@@ -107,9 +107,9 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
-          echo "service_account=${SERVICE_ACCOUNT}" >> $GITHUB_OUTPUT
-          echo "provider_name=${PROVIDER_NAME}" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
+          echo "service_account=${SERVICE_ACCOUNT}" >> "${GITHUB_OUTPUT}"
+          echo "provider_name=${PROVIDER_NAME}" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.tag.main.gcp-workload-identity.slsa3.yml
+++ b/.github/workflows/e2e.container.tag.main.gcp-workload-identity.slsa3.yml
@@ -107,9 +107,9 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
-          echo "::set-output name=service_account::${SERVICE_ACCOUNT}"
-          echo "::set-output name=provider_name::${PROVIDER_NAME}"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "service_account=${SERVICE_ACCOUNT}" >> $GITHUB_OUTPUT
+          echo "provider_name=${PROVIDER_NAME}" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.tag.main.registry-username-secret.yml
+++ b/.github/workflows/e2e.container.tag.main.registry-username-secret.yml
@@ -96,7 +96,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.tag.main.registry-username-secret.yml
+++ b/.github/workflows/e2e.container.tag.main.registry-username-secret.yml
@@ -96,7 +96,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.branch1.default.slsa3.yml
@@ -77,7 +77,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.branch1.default.slsa3.yml
@@ -77,7 +77,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml
@@ -64,7 +64,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml
@@ -64,7 +64,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml
@@ -64,7 +64,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml
@@ -64,7 +64,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.default.slsa3.yml
@@ -81,7 +81,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.default.slsa3.yml
@@ -81,7 +81,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.main.workflow_inputs.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.workflow_inputs.slsa3.yml
@@ -86,7 +86,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.container.workflow_dispatch.main.workflow_inputs.slsa3.yml
+++ b/.github/workflows/e2e.container.workflow_dispatch.main.workflow_inputs.slsa3.yml
@@ -86,7 +86,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "::set-output name=image::$image_name"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
 
   # Generate SLSA provenance for the image
   # Upload the provenance to ghcr.io

--- a/.github/workflows/e2e.docker-based.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.docker-based.push.main.default.slsa3.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           name=$(find outputs/ -type f | head -1)
           cp $name .
-          echo "name=$(basename $name)" >> $GITHUB_OUTPUT
+          echo "name=$(basename $name)" >> "${GITHUB_OUTPUT}"
       - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}

--- a/.github/workflows/e2e.docker-based.schedule.main.default.slsa3.yml
+++ b/.github/workflows/e2e.docker-based.schedule.main.default.slsa3.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           name=$(find outputs/ -type f | head -1)
           cp $name .
-          echo "name=$(basename $name)" >> $GITHUB_OUTPUT
+          echo "name=$(basename $name)" >> "${GITHUB_OUTPUT}"
       - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}

--- a/.github/workflows/e2e.docker-based.schedule.main.gcp-workload-identity.slsa3.yml
+++ b/.github/workflows/e2e.docker-based.schedule.main.gcp-workload-identity.slsa3.yml
@@ -115,10 +115,10 @@ jobs:
           repo_digest=$(docker inspect --format='{{index .RepoDigests 0}}' $image_name:main)
           echo $repo_digest
 
-          echo "::set-output name=image::$image_name"
-          echo "::set-output name=digest::${repo_digest#*@}"
-          echo "::set-output name=service_account::${SERVICE_ACCOUNT}"
-          echo "::set-output name=provider_name::${PROVIDER_NAME}"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "digest=${repo_digest#*@}" >> $GITHUB_OUTPUT
+          echo "service_account=${SERVICE_ACCOUNT}" >> $GITHUB_OUTPUT
+          echo "provider_name=${PROVIDER_NAME}" >> $GITHUB_OUTPUT
 
   build:
     permissions:

--- a/.github/workflows/e2e.docker-based.schedule.main.gcp-workload-identity.slsa3.yml
+++ b/.github/workflows/e2e.docker-based.schedule.main.gcp-workload-identity.slsa3.yml
@@ -115,10 +115,10 @@ jobs:
           repo_digest=$(docker inspect --format='{{index .RepoDigests 0}}' $image_name:main)
           echo $repo_digest
 
-          echo "image=$image_name" >> $GITHUB_OUTPUT
-          echo "digest=${repo_digest#*@}" >> $GITHUB_OUTPUT
-          echo "service_account=${SERVICE_ACCOUNT}" >> $GITHUB_OUTPUT
-          echo "provider_name=${PROVIDER_NAME}" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
+          echo "digest=${repo_digest#*@}" >> "${GITHUB_OUTPUT}"
+          echo "service_account=${SERVICE_ACCOUNT}" >> "${GITHUB_OUTPUT}"
+          echo "provider_name=${PROVIDER_NAME}" >> "${GITHUB_OUTPUT}"
 
   build:
     permissions:
@@ -148,7 +148,7 @@ jobs:
         run: |
           name=$(find outputs/ -type f | head -1)
           cp $name .
-          echo "name=$(basename $name)" >> $GITHUB_OUTPUT
+          echo "name=$(basename $name)" >> "${GITHUB_OUTPUT}"
       - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}

--- a/.github/workflows/e2e.docker-based.schedule.main.matrix.slsa3.yml
+++ b/.github/workflows/e2e.docker-based.schedule.main.matrix.slsa3.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           name=$(find outputs/ -type f | head -1)
           cp $name .
-          echo "name=$(basename $name)" >> $GITHUB_OUTPUT
+          echo "name=$(basename $name)" >> "${GITHUB_OUTPUT}"
       - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}

--- a/.github/workflows/e2e.docker-based.schedule.main.registry-username-secret.yml
+++ b/.github/workflows/e2e.docker-based.schedule.main.registry-username-secret.yml
@@ -48,8 +48,8 @@ jobs:
           repo_digest=$(docker inspect --format='{{index .RepoDigests 0}}' $image_name:main)
           echo $repo_digest
 
-          echo "::set-output name=image::$image_name"
-          echo "::set-output name=digest::${repo_digest#*@}"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "digest=${repo_digest#*@}" >> $GITHUB_OUTPUT
 
   build:
     permissions:

--- a/.github/workflows/e2e.docker-based.schedule.main.registry-username-secret.yml
+++ b/.github/workflows/e2e.docker-based.schedule.main.registry-username-secret.yml
@@ -48,8 +48,8 @@ jobs:
           repo_digest=$(docker inspect --format='{{index .RepoDigests 0}}' $image_name:main)
           echo $repo_digest
 
-          echo "image=$image_name" >> $GITHUB_OUTPUT
-          echo "digest=${repo_digest#*@}" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
+          echo "digest=${repo_digest#*@}" >> "${GITHUB_OUTPUT}"
 
   build:
     permissions:
@@ -82,7 +82,7 @@ jobs:
         run: |
           name=$(find outputs/ -type f | head -1)
           cp $name .
-          echo "name=$(basename $name)" >> $GITHUB_OUTPUT
+          echo "name=$(basename $name)" >> "${GITHUB_OUTPUT}"
       - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}

--- a/.github/workflows/e2e.docker-based.schedule.main.registry-username.yml
+++ b/.github/workflows/e2e.docker-based.schedule.main.registry-username.yml
@@ -94,8 +94,8 @@ jobs:
           repo_digest=$(docker inspect --format='{{index .RepoDigests 0}}' $image_name:main)
           echo $repo_digest
 
-          echo "image=$image_name" >> $GITHUB_OUTPUT
-          echo "digest=${repo_digest#*@}" >> $GITHUB_OUTPUT
+          echo "image=$image_name" >> "${GITHUB_OUTPUT}"
+          echo "digest=${repo_digest#*@}" >> "${GITHUB_OUTPUT}"
 
           # try a docker pull
           docker pull "$image_name@${repo_digest#*@}"
@@ -131,7 +131,7 @@ jobs:
         run: |
           name=$(find outputs/ -type f | head -1)
           cp $name .
-          echo "name=$(basename $name)" >> $GITHUB_OUTPUT
+          echo "name=$(basename $name)" >> "${GITHUB_OUTPUT}"
       - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}

--- a/.github/workflows/e2e.docker-based.schedule.main.registry-username.yml
+++ b/.github/workflows/e2e.docker-based.schedule.main.registry-username.yml
@@ -94,8 +94,8 @@ jobs:
           repo_digest=$(docker inspect --format='{{index .RepoDigests 0}}' $image_name:main)
           echo $repo_digest
 
-          echo "::set-output name=image::$image_name"
-          echo "::set-output name=digest::${repo_digest#*@}"
+          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "digest=${repo_digest#*@}" >> $GITHUB_OUTPUT
 
           # try a docker pull
           docker pull "$image_name@${repo_digest#*@}"

--- a/.github/workflows/e2e.docker-based.tag.main.default.slsa3.yml
+++ b/.github/workflows/e2e.docker-based.tag.main.default.slsa3.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           name=$(find outputs/ -type f | head -1)
           cp $name .
-          echo "name=$(basename $name)" >> $GITHUB_OUTPUT
+          echo "name=$(basename $name)" >> "${GITHUB_OUTPUT}"
       - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}

--- a/.github/workflows/e2e.docker-based.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.docker-based.workflow_dispatch.main.default.slsa3.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           name=$(find outputs/ -type f | head -1)
           cp $name .
-          echo "name=$(basename $name)" >> $GITHUB_OUTPUT
+          echo "name=$(basename $name)" >> "${GITHUB_OUTPUT}"
       - uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}

--- a/.github/workflows/e2e.gcb.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.gcb.push.main.default.slsa3.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Found build with build id ${BUILD_ID}..."
 
           export IMAGE_DIGEST=$(gcloud builds describe ${BUILD_ID} --project=slsa-tooling --region=us-west2 --format="value(results.images[0].digest)")
-          echo "::set-output name=image::${IMAGE_REGISTRY}"/"${IMAGE_NAME}@${IMAGE_DIGEST}"
+          echo "image=${IMAGE_REGISTRY}"/"${IMAGE_NAME}@${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
           echo "Retrieved image digest ${IMAGE_DIGEST}..."
 
           # Get latest builds provenance

--- a/.github/workflows/e2e.gcb.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.gcb.push.main.default.slsa3.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Found build with build id ${BUILD_ID}..."
 
           export IMAGE_DIGEST=$(gcloud builds describe ${BUILD_ID} --project=slsa-tooling --region=us-west2 --format="value(results.images[0].digest)")
-          echo "image=${IMAGE_REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE_REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}" >> "${GITHUB_OUTPUT}"
           echo "Retrieved image digest ${IMAGE_DIGEST}..."
 
           # Get latest builds provenance

--- a/.github/workflows/e2e.gcb.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.gcb.push.main.default.slsa3.yml
@@ -65,11 +65,11 @@ jobs:
           echo "Found build with build id ${BUILD_ID}..."
 
           export IMAGE_DIGEST=$(gcloud builds describe ${BUILD_ID} --project=slsa-tooling --region=us-west2 --format="value(results.images[0].digest)")
-          echo "image=${IMAGE_REGISTRY}"/"${IMAGE_NAME}@${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE_REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
           echo "Retrieved image digest ${IMAGE_DIGEST}..."
 
           # Get latest builds provenance
-          gcloud artifacts docker images describe "${IMAGE_REGISTRY}"/"${IMAGE_NAME}@${IMAGE_DIGEST}" --show-provenance --format json > provenance.json
+          gcloud artifacts docker images describe "${IMAGE_REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}" --show-provenance --format json > provenance.json
           echo "::set-output name=provenance-name::provenance.json"
       - name: Upload provenance
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/e2e.gcb.tag.main.annotated-build.slsa3.yml
+++ b/.github/workflows/e2e.gcb.tag.main.annotated-build.slsa3.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Found build with build id ${BUILD_ID}..."
 
           export IMAGE_DIGEST=$(gcloud builds describe ${BUILD_ID} --project=slsa-tooling --region=us-west2 --format="value(results.images[0].digest)")
-          echo "::set-output name=image::${IMAGE_REGISTRY}"/"${IMAGE_NAME}@${IMAGE_DIGEST}"
+          echo "image=${IMAGE_REGISTRY}"/"${IMAGE_NAME}@${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
           echo "Retrieved image digest ${IMAGE_DIGEST}..."
 
           # Get latest builds provenance

--- a/.github/workflows/e2e.gcb.tag.main.annotated-build.slsa3.yml
+++ b/.github/workflows/e2e.gcb.tag.main.annotated-build.slsa3.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Found build with build id ${BUILD_ID}..."
 
           export IMAGE_DIGEST=$(gcloud builds describe ${BUILD_ID} --project=slsa-tooling --region=us-west2 --format="value(results.images[0].digest)")
-          echo "image=${IMAGE_REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE_REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}" >> "${GITHUB_OUTPUT}"
           echo "Retrieved image digest ${IMAGE_DIGEST}..."
 
           # Get latest builds provenance

--- a/.github/workflows/e2e.gcb.tag.main.annotated-build.slsa3.yml
+++ b/.github/workflows/e2e.gcb.tag.main.annotated-build.slsa3.yml
@@ -65,11 +65,11 @@ jobs:
           echo "Found build with build id ${BUILD_ID}..."
 
           export IMAGE_DIGEST=$(gcloud builds describe ${BUILD_ID} --project=slsa-tooling --region=us-west2 --format="value(results.images[0].digest)")
-          echo "image=${IMAGE_REGISTRY}"/"${IMAGE_NAME}@${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE_REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
           echo "Retrieved image digest ${IMAGE_DIGEST}..."
 
           # Get latest builds provenance
-          gcloud artifacts docker images describe "${IMAGE_REGISTRY}"/"${IMAGE_NAME}@${IMAGE_DIGEST}" --show-provenance --format json > provenance.json
+          gcloud artifacts docker images describe "${IMAGE_REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}" --show-provenance --format json > provenance.json
           echo "::set-output name=provenance-name::provenance.json"
       - name: Upload provenance
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/e2e.generic.push.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.push.branch1.default.slsa3.yml
@@ -38,7 +38,7 @@ jobs:
           THIS_FILE=$(e2e_this_file)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
           if [[ "$BRANCH" == "$GITHUB_REF_NAME" ]]; then
-            echo "::set-output name=continue::yes"
+            echo "continue=yes" >> $GITHUB_OUTPUT
           fi
 
   build:
@@ -75,7 +75,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.push.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.push.branch1.default.slsa3.yml
@@ -38,7 +38,7 @@ jobs:
           THIS_FILE=$(e2e_this_file)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
           if [[ "$BRANCH" == "$GITHUB_REF_NAME" ]]; then
-            echo "continue=yes" >> $GITHUB_OUTPUT
+            echo "continue=yes" >> "${GITHUB_OUTPUT}"
           fi
 
   build:
@@ -75,7 +75,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.push.main.default.slsa3.yml
@@ -55,7 +55,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     if: github.event_name == 'push' && github.event.head_commit.message == github.workflow

--- a/.github/workflows/e2e.generic.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.push.main.default.slsa3.yml
@@ -55,7 +55,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     if: github.event_name == 'push' && github.event.head_commit.message == github.workflow

--- a/.github/workflows/e2e.generic.push.main.upload-tag-name.slsa3.yml
+++ b/.github/workflows/e2e.generic.push.main.upload-tag-name.slsa3.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           bazelisk build //:hello
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
-          echo "binary-name=hello" >> "$GITHUB_OUTPUT"
+          echo "binary-name=hello" >> ""${GITHUB_OUTPUT}""
       - name: Upload binary
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
@@ -64,11 +64,11 @@ jobs:
         run: |
           set -euo pipefail
           source "./.github/workflows/scripts/e2e-utils.sh"
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "$GITHUB_OUTPUT"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> ""${GITHUB_OUTPUT}""
 
           filename="$(e2e_this_file)"
           filename="${filename%.*}" # Remove the file extension.
-          echo "upload-tag-name=${filename}" >> "$GITHUB_OUTPUT"
+          echo "upload-tag-name=${filename}" >> ""${GITHUB_OUTPUT}""
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.release.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.release.main.default.slsa3.yml
@@ -71,7 +71,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.release.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.release.main.default.slsa3.yml
@@ -71,7 +71,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.schedule.main.adversarial-invalidpath.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.adversarial-invalidpath.slsa3.yml
@@ -39,7 +39,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=$(sha256sum artifact1 artifact2 | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "hashes=$(sha256sum artifact1 artifact2 | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.adversarial-invalidpath.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.adversarial-invalidpath.slsa3.yml
@@ -39,7 +39,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "::set-output name=hashes::$(sha256sum artifact1 artifact2 | base64 -w0)"
+          echo "hashes=$(sha256sum artifact1 artifact2 | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
@@ -39,7 +39,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=$(sha256sum somethinginvalid | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "hashes=$(echo something invalid | sha256sum | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
@@ -39,7 +39,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "::set-output name=hashes::something invalid | base64 -w0)"
+          echo "hashes=something invalid | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
@@ -39,7 +39,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=$(echo something invalid | sha256sum | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "hashes=$(echo artifact1 somethinginvalid | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
@@ -39,7 +39,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=something invalid | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "hashes=$(sha256sum somethinginvalid | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.attestation-name.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.attestation-name.slsa3.yml
@@ -43,7 +43,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.attestation-name.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.attestation-name.slsa3.yml
@@ -43,7 +43,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
@@ -43,7 +43,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
@@ -43,7 +43,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.multi-subjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.multi-subjects.slsa3.yml
@@ -41,7 +41,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "::set-output name=hashes::$(sha256sum artifact1 artifact2 artifact3 | base64 -w0)"
+          echo "hashes=$(sha256sum artifact1 artifact2 artifact3 | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.multi-subjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.multi-subjects.slsa3.yml
@@ -41,7 +41,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=$(sha256sum artifact1 artifact2 artifact3 | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "hashes=$(sha256sum artifact1 artifact2 artifact3 | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.schedule.main.multi-uses.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.multi-uses.slsa3.yml
@@ -37,7 +37,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "::set-output name=hashes::$(sha256sum artifact1 | base64 -w0)"
+          echo "hashes=$(sha256sum artifact1 | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance-one:
     needs: [build-one]
@@ -104,7 +104,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "::set-output name=hashes::$(sha256sum artifact1 | base64 -w0)"
+          echo "hashes=$(sha256sum artifact1 | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance-two:
     needs: [build-two]

--- a/.github/workflows/e2e.generic.schedule.main.multi-uses.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.multi-uses.slsa3.yml
@@ -37,7 +37,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=$(sha256sum artifact1 | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "hashes=$(sha256sum artifact1 | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance-one:
     needs: [build-one]
@@ -104,7 +104,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=$(sha256sum artifact1 | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "hashes=$(sha256sum artifact1 | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance-two:
     needs: [build-two]

--- a/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
@@ -73,7 +73,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
@@ -73,7 +73,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.tag.main.annotated.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.annotated.slsa3.yml
@@ -63,7 +63,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 ... | base64 -w0
-          echo "::set-output name=digest::$(sha256sum artifact1 | base64 -w0)"
+          echo "digest=$(sha256sum artifact1 | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.tag.main.annotated.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.annotated.slsa3.yml
@@ -63,7 +63,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 ... | base64 -w0
-          echo "digest=$(sha256sum artifact1 | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum artifact1 | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.tag.main.assets.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.assets.slsa3.yml
@@ -69,7 +69,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.tag.main.assets.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.assets.slsa3.yml
@@ -69,7 +69,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.tag.main.goreleaser-assets-multi-subjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.goreleaser-assets-multi-subjects.slsa3.yml
@@ -78,7 +78,7 @@ jobs:
           set -euo pipefail
 
           checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> ""${GITHUB_OUTPUT}""
 
   provenance:
     needs: [shim, build]

--- a/.github/workflows/e2e.generic.workflow_dispatch.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.branch1.default.slsa3.yml
@@ -58,7 +58,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/e2e.generic.workflow_dispatch.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.branch1.default.slsa3.yml
@@ -58,7 +58,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml
@@ -23,7 +23,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "digests=$(sha256sum artifact1 artifact2 | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digests=$(sha256sum artifact1 artifact2 | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-builder-binary.slsa3.yml
@@ -23,7 +23,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "::set-output name=digests::$(sha256sum artifact1 artifact2 | base64 -w0)"
+          echo "digests=$(sha256sum artifact1 artifact2 | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml
@@ -23,7 +23,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "digests=$(sha256sum artifact1 artifact2 | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digests=$(sha256sum artifact1 artifact2 | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.adversarial-verifier-binary.slsa3.yml
@@ -23,7 +23,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "::set-output name=digests::$(sha256sum artifact1 artifact2 | base64 -w0)"
+          echo "digests=$(sha256sum artifact1 artifact2 | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [build]

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.default.slsa3.yml
@@ -54,7 +54,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.default.slsa3.yml
@@ -54,7 +54,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.tagname.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.tagname.slsa3.yml
@@ -52,7 +52,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=$(sha256sum artifact1 | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "hashes=$(sha256sum artifact1 | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [release, build]

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.tagname.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.tagname.slsa3.yml
@@ -52,7 +52,7 @@ jobs:
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
           # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "::set-output name=hashes::$(sha256sum artifact1 | base64 -w0)"
+          echo "hashes=$(sha256sum artifact1 | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [release, build]

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.workflow_inputs.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.workflow_inputs.slsa3.yml
@@ -59,7 +59,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "${GITHUB_OUTPUT}"
 
   provenance:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.workflow_inputs.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.workflow_inputs.slsa3.yml
@@ -59,7 +59,7 @@ jobs:
           BINARY_NAME: ${{ steps.build.outputs.binary-name }}
         run: |
           set -euo pipefail
-          echo "::set-output name=digest::$(sha256sum $BINARY_NAME | base64 -w0)"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> $GITHUB_OUTPUT
 
   provenance:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/e2e.go.push.branch1.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.branch1.config-ldflags.slsa3.yml
@@ -41,7 +41,7 @@ jobs:
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
           if [[ "$BRANCH" == "${{ github.ref_name }}" ]]; then
-            echo "continue=yes" >> $GITHUB_OUTPUT
+            echo "continue=yes" >> "${GITHUB_OUTPUT}"
           fi
 
   args:
@@ -63,9 +63,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.push.branch1.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.branch1.config-ldflags.slsa3.yml
@@ -41,7 +41,7 @@ jobs:
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
           if [[ "$BRANCH" == "${{ github.ref_name }}" ]]; then
-            echo "::set-output name=continue::yes"
+            echo "continue=yes" >> $GITHUB_OUTPUT
           fi
 
   args:
@@ -63,9 +63,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.push.main.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.main.config-ldflags.slsa3.yml
@@ -41,9 +41,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     if: github.event_name == 'push' && github.event.head_commit.message == github.workflow

--- a/.github/workflows/e2e.go.push.main.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.main.config-ldflags.slsa3.yml
@@ -41,9 +41,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     if: github.event_name == 'push' && github.event.head_commit.message == github.workflow

--- a/.github/workflows/e2e.go.release.main.config-ldflags-assets-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-assets-tag.slsa3.yml
@@ -60,9 +60,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.release.main.config-ldflags-assets-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-assets-tag.slsa3.yml
@@ -60,9 +60,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.release.main.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-assets.slsa3.yml
@@ -60,9 +60,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.release.main.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-assets.slsa3.yml
@@ -60,9 +60,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.release.main.config-ldflags-noassets.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-noassets.slsa3.yml
@@ -54,9 +54,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
   build:
     needs: [shim, args]
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag'

--- a/.github/workflows/e2e.go.release.main.config-ldflags-noassets.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-noassets.slsa3.yml
@@ -54,9 +54,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
   build:
     needs: [shim, args]
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag'

--- a/.github/workflows/e2e.go.schedule.main.config-ldflags-main-dir.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-ldflags-main-dir.slsa3.yml
@@ -32,11 +32,11 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
           # Note: this must be the same path defined in the config file.
-          echo "main=-X main.gitMain=$GO_MAIN" >> $GITHUB_OUTPUT
+          echo "main=-X main.gitMain=$GO_MAIN" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [args]

--- a/.github/workflows/e2e.go.schedule.main.config-ldflags-main-dir.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-ldflags-main-dir.slsa3.yml
@@ -32,11 +32,11 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
           # Note: this must be the same path defined in the config file.
-          echo "::set-output name=main::-X main.gitMain=$GO_MAIN"
+          echo "main=-X main.gitMain=$GO_MAIN" >> $GITHUB_OUTPUT
 
   build:
     needs: [args]

--- a/.github/workflows/e2e.go.schedule.main.config-ldflags-main.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-ldflags-main.slsa3.yml
@@ -31,11 +31,11 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
           # Note: this must be the same path defined in the config file.
-          echo "main=-X main.gitMain=$GO_MAIN" >> $GITHUB_OUTPUT
+          echo "main=-X main.gitMain=$GO_MAIN" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [args]

--- a/.github/workflows/e2e.go.schedule.main.config-ldflags-main.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-ldflags-main.slsa3.yml
@@ -31,11 +31,11 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
           # Note: this must be the same path defined in the config file.
-          echo "::set-output name=main::-X main.gitMain=$GO_MAIN"
+          echo "main=-X main.gitMain=$GO_MAIN" >> $GITHUB_OUTPUT
 
   build:
     needs: [args]

--- a/.github/workflows/e2e.go.tag.branch1.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.branch1.config-ldflags-assets.slsa3.yml
@@ -54,9 +54,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.branch1.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.branch1.config-ldflags-assets.slsa3.yml
@@ -54,9 +54,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.adversarial-asset-binary.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.adversarial-asset-binary.slsa3.yml
@@ -70,9 +70,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.adversarial-asset-binary.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.adversarial-asset-binary.slsa3.yml
@@ -70,9 +70,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.adversarial-asset-provenance.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.adversarial-asset-provenance.slsa3.yml
@@ -76,9 +76,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.adversarial-asset-provenance.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.adversarial-asset-provenance.slsa3.yml
@@ -76,9 +76,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-draft-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-draft-tag.slsa3.yml
@@ -63,9 +63,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-draft-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-draft-tag.slsa3.yml
@@ -63,9 +63,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-prerelease-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-prerelease-tag.slsa3.yml
@@ -61,9 +61,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-prerelease-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-prerelease-tag.slsa3.yml
@@ -61,9 +61,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-tag.slsa3.yml
@@ -61,9 +61,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-tag.slsa3.yml
@@ -61,9 +61,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets.slsa3.yml
@@ -56,9 +56,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets.slsa3.yml
@@ -56,9 +56,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-noassets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-noassets.slsa3.yml
@@ -55,9 +55,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
   build:
     needs: [shim, args]
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-noassets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-noassets.slsa3.yml
@@ -55,9 +55,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
   build:
     needs: [shim, args]
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'

--- a/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
@@ -37,7 +37,7 @@ jobs:
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
           if [[ "$BRANCH" == "${{ github.ref_name }}" ]]; then
-            echo "continue=yes" >> $GITHUB_OUTPUT
+            echo "continue=yes" >> "${GITHUB_OUTPUT}"
           fi
 
   args:
@@ -59,9 +59,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
-          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
-          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=-X main.gitVersion=v1.2.3" >> "${GITHUB_OUTPUT}"
+          echo "commit=-X main.gitCommit=abcdef" >> "${GITHUB_OUTPUT}"
+          echo "branch=-X main.gitBranch=$BRANCH" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
@@ -37,7 +37,7 @@ jobs:
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
           if [[ "$BRANCH" == "${{ github.ref_name }}" ]]; then
-            echo "::set-output name=continue::yes"
+            echo "continue=yes" >> $GITHUB_OUTPUT
           fi
 
   args:
@@ -59,9 +59,9 @@ jobs:
 
           THIS_FILE=$(gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | jq -r '.path' | cut -d '/' -f3)
           BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
-          echo "::set-output name=version::-X main.gitVersion=v1.2.3"
-          echo "::set-output name=commit::-X main.gitCommit=abcdef"
-          echo "::set-output name=branch::-X main.gitBranch=$BRANCH"
+          echo "version=-X main.gitVersion=v1.2.3" >> $GITHUB_OUTPUT
+          echo "commit=-X main.gitCommit=abcdef" >> $GITHUB_OUTPUT
+          echo "branch=-X main.gitBranch=$BRANCH" >> $GITHUB_OUTPUT
 
   build:
     needs: [shim, args]

--- a/.github/workflows/e2e.nodejs.push.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.push.branch1.default.slsa3.yml
@@ -41,7 +41,7 @@ jobs:
           this_file=$(e2e_this_file)
           branch=$(echo "${this_file}" | cut -d '.' -f4)
           if [[ "${branch}" == "$GITHUB_REF_NAME" ]]; then
-            echo "continue=yes" >>"$GITHUB_OUTPUT"
+            echo "continue=yes" >>""${GITHUB_OUTPUT}""
           fi
 
   build:

--- a/.github/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml
+++ b/.github/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml
@@ -34,13 +34,13 @@ jobs:
         id: create_name
         run: |
           if [ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]; then
-            echo "binary-name=gha_generic-binary-linux-amd64-workflow_dispatch" >> "$GITHUB_OUTPUT"
-            echo "config-file=.github/configs-go/config-ldflags-workflow_dispatch.yml" >> "$GITHUB_OUTPUT"
+            echo "binary-name=gha_generic-binary-linux-amd64-workflow_dispatch" >> ""${GITHUB_OUTPUT}""
+            echo "config-file=.github/configs-go/config-ldflags-workflow_dispatch.yml" >> ""${GITHUB_OUTPUT}""
             exit 0
           fi
           # This must be a tag event.
-          echo "binary-name=gha_generic-binary-linux-amd64-${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          echo "config-file=.github/configs-go/config-ldflags-tag-name.yml" >> "$GITHUB_OUTPUT"
+          echo "binary-name=gha_generic-binary-linux-amd64-${GITHUB_REF_NAME}" >> ""${GITHUB_OUTPUT}""
+          echo "config-file=.github/configs-go/config-ldflags-tag-name.yml" >> ""${GITHUB_OUTPUT}""
 
   build:
     needs: [generate_name]
@@ -62,7 +62,7 @@ jobs:
         run: |
           bazelisk build //:hello
           cp bazel-bin/hello_/hello $BINARY_NAME # Copy binary from Bazel path to root
-          echo "binary-name=$BINARY_NAME" >> "$GITHUB_OUTPUT"
+          echo "binary-name=$BINARY_NAME" >> ""${GITHUB_OUTPUT}""
       - name: Upload binary
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
@@ -75,7 +75,7 @@ jobs:
         id: hash
         run: |
           set -euo pipefail
-          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> "$GITHUB_OUTPUT"
+          echo "digest=$(sha256sum $BINARY_NAME | base64 -w0)" >> ""${GITHUB_OUTPUT}""
 
   gha_generic:
     needs: [build]
@@ -147,7 +147,7 @@ jobs:
           # NOTE: The digest output from docker/build-push-action is of the
           # form "sha256:<digest>"
           image_name="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          echo "image=$image_name" >> "$GITHUB_OUTPUT"
+          echo "image=$image_name" >> ""${GITHUB_OUTPUT}""
 
   gha_container:
     needs: container_build

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 
 	for _, filename := range filenameFlags {
 		fmt.Println("Writing to filename: ", filename)
+		//nolint:gosec // the builder must be able to read this file
 		if err := os.WriteFile(filename, []byte(*content), 0o644); err != nil {
 			fmt.Println("error writing to file: %w", err)
 			panic(err)


### PR DESCRIPTION
Fixes https://github.com/slsa-framework/example-package/issues/176

The first commit is an application of a command:
```
find .  -type f -name "*.yml" -exec sed -i 's/echo \"::set-output name=\(\w*\)::\(.*\)"/echo \"\1=\2\" >> $GITHUB_OUTPUT/' {} +
```

The second commit is some manual updates.

Please verify!