### PR TITLE
feat: Use e2e-bootstrap.sh in Node.js tests

### DIFF
--- a/.github/workflows/e2e.nodejs.create.main.default.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.create.main.default.slsa3.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       # Bumps the package version pushes, creates a git tag, and pushes the tag.
-      - run: ./.github/workflows/scripts/e2e-nodejs-push.sh
+      - run: ./.github/workflows/scripts/e2e-bootstrap.sh
 
   if-bootstrap-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.nodejs.push.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.push.branch1.default.slsa3.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [branch1]
+    paths:
+      - "e2e/e2e.nodejs.push.branch1.default.slsa3.yml.txt"
 
 permissions: read-all
 
@@ -25,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       # Bumps the package version pushes, creates a git tag, and pushes the tag.
-      - run: ./.github/workflows/scripts/e2e-nodejs-push.sh
+      - run: ./.github/workflows/scripts/e2e-bootstrap.sh
 
   if-bootstrap-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.nodejs.push.main.adversarial.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.push.main.adversarial.slsa3.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths:
+      - "e2e/e2e.nodejs.push.main.adversarial.slsa3.yml.txt"
 
 permissions: read-all
 
@@ -25,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       # Bumps the package version pushes, creates a git tag, and pushes the tag.
-      - run: ./.github/workflows/scripts/e2e-nodejs-push.sh
+      - run: ./.github/workflows/scripts/e2e-bootstrap.sh
 
   if-bootstrap-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.nodejs.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.push.main.default.slsa3.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths:
+      - "e2e/e2e.nodejs.push.main.default.slsa3.yml.txt"
 
 permissions: read-all
 
@@ -25,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       # Bumps the package version pushes, creates a git tag, and pushes the tag.
-      - run: ./.github/workflows/scripts/e2e-nodejs-push.sh
+      - run: ./.github/workflows/scripts/e2e-bootstrap.sh
 
   if-bootstrap-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.nodejs.push.main.disttag.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.push.main.disttag.slsa3.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths:
+      - "e2e/e2e.nodejs.push.main.disttag.slsa3.yml.txt"
 
 permissions: read-all
 
@@ -27,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       # Bumps the package version pushes, creates a git tag, and pushes the tag.
-      - run: ./.github/workflows/scripts/e2e-nodejs-push.sh
+      - run: ./.github/workflows/scripts/e2e-bootstrap.sh
 
   if-bootstrap-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.nodejs.release.main.default.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.release.main.default.slsa3.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       # Bumps the package version pushes, creates a git tag, and pushes the tag.
-      - run: ./.github/workflows/scripts/e2e-nodejs-push.sh
+      - run: ./.github/workflows/scripts/e2e-bootstrap.sh
 
   if-bootstrap-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.nodejs.tag.main.default.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.tag.main.default.slsa3.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       # Bumps the package version pushes, creates a git tag, and pushes the tag.
-      - run: ./.github/workflows/scripts/e2e-nodejs-push.sh
+      - run: ./.github/workflows/scripts/e2e-bootstrap.sh
 
   if-bootstrap-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.nodejs.tag.main.unscoped.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.tag.main.unscoped.slsa3.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       # Bumps the package version pushes, creates a git tag, and pushes the tag.
-      - run: ./.github/workflows/scripts/e2e-nodejs-push.sh
+      - run: ./.github/workflows/scripts/e2e-bootstrap.sh
 
   if-bootstrap-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.nodejs.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.workflow_dispatch.main.default.slsa3.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       # Bumps the package version pushes, creates a git tag, and pushes the tag.
-      - run: ./.github/workflows/scripts/e2e-nodejs-push.sh
+      - run: ./.github/workflows/scripts/e2e-bootstrap.sh
 
   if-bootstrap-failed:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates #228 

Update Node.js builder e2e tests to use `e2e-bootstrap.sh` and filter `push` trigger on e2e text files to avoid concurrency issue described in #228.