### PR TITLE
ci: Make renovate schedule monthly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "schedule": ["every weekend"],
+  "schedule": ["before 4 am on the first day of the month"],
+  "vulnerabilityAlerts": {
+    "schedule": "before 4am"
+  },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
Makes renovate create PRs for dependency updates monthly rather than weekly.
https://docs.renovatebot.com/presets-schedule/#schedulemonthly

Also sets vulnerability PRs to be scheduled daily.
https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts