### PR TITLE
Fix provenance registry typo

### DIFF
--- a/.github/workflows/e2e.container.schedule.main.provenance-registry.slsa3.yml
+++ b/.github/workflows/e2e.container.schedule.main.provenance-registry.slsa3.yml
@@ -18,7 +18,7 @@ env:
   GH_TOKEN: ${{ secrets.E2E_CONTAINER_TOKEN }}
   ISSUE_REPOSITORY: slsa-framework/slsa-github-generator
 
-  IMAGE_REGISTRY: gchr.io
+  IMAGE_REGISTRY: ghcr.io
 
   PROVENACE_REGISTRY: docker.io
   # NOTE: This pushes a container image to a "namespace" under the


### PR DESCRIPTION
@laurentsimon This should probably fix the typo in the `registry` leading to error in https://github.com/slsa-framework/slsa-github-generator/issues/3024#issuecomment-1852568509