### PR TITLE
feat: use provenance-repository input for slsa-verifier

### DIFF
--- a/.github/workflows/e2e.container.schedule.main.provenance-registry.slsa3.yml
+++ b/.github/workflows/e2e.container.schedule.main.provenance-registry.slsa3.yml
@@ -112,7 +112,7 @@ jobs:
       digest: ${{ needs.build.outputs.digest }}
       registry-username: ${{ github.actor }}
       provenance-registry-username: ${{ needs.provenance-metadata.outputs.username }}
-      provenance-registry: ${{ needs.provenance-metadata.outputs.image }}
+      provenance-repository: ${{ needs.provenance-metadata.outputs.image }}
       compile-generator: true
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }} # Github token for contaner image
@@ -166,7 +166,7 @@ jobs:
           go-version: "1.20"
       - env:
           CONTAINER: "${{ env.container }}"
-          PROVENANCE: "${{ env.provenance_file }}"
+          PROVENANCE_REPOSITORY: ${{ needs.provenance-metadata.outputs.image }}
         run: ./.github/workflows/scripts/e2e.container.default.verify.sh
 
   if-succeeded:

--- a/.github/workflows/scripts/e2e-verify.common.sh
+++ b/.github/workflows/scripts/e2e-verify.common.sh
@@ -321,6 +321,7 @@ verify_provenance_authenticity() {
     CONTAINER=${CONTAINER:-}
     GITHUB_REF_NAME=${GITHUB_REF_NAME:-}
     PROVENANCE=${PROVENANCE:-}
+    PROVENANCE_REPOSITORY=${PROVENANCE_REPOSITORY:-}
 
     local verifier="$1"
     local tag="$2"
@@ -381,6 +382,10 @@ verify_provenance_authenticity() {
     provenanceArg=()
     if [[ "$build_type" == "nodejs" ]]; then
         read -ra provenanceArg <<<"--attestations-path ${ATTESTATIONS}"
+    elif [[ "$build_type" == "container" ]]; then
+        if [[ -n "$PROVENANCE_REPOSITORY" ]]; then
+            read -ra provenanceArg <<<"$($argr "provenance-repository") ${PROVENANCE_REPOSITORY}"
+        fi
     elif [[ "$build_type" != "container" ]]; then
         read -ra provenanceArg <<<"$($argr "provenance") ${PROVENANCE}"
     fi
@@ -798,6 +803,7 @@ _new_verifier_args() {
     case $arg in
     artifact-path) echo '' ;;
     provenance) echo '--provenance-path' ;;
+    provenance-repository) echo '--provenance-repository' ;;
     source) echo '--source-uri' ;;
     tag) echo '--source-tag' ;;
     versioned-tag) echo '--source-versioned-tag' ;;

--- a/.github/workflows/scripts/e2e.container.default.verify.sh
+++ b/.github/workflows/scripts/e2e.container.default.verify.sh
@@ -8,6 +8,7 @@ GITHUB_REF=${GITHUB_REF:-}
 GITHUB_REF_NAME=${GITHUB_REF_NAME:-}
 GITHUB_REF_TYPE=${GITHUB_REF_TYPE:-}
 PROVENANCE=${PROVENANCE:-}
+PROVENANCE_REPOSITORY=${PROVENANCE_REPOSITORY:-}
 CONTAINER=${CONTAINER:-}
 RUNNER_DEBUG=${RUNNER_DEBUG:-}
 if [[ -n "${RUNNER_DEBUG}" ]]; then
@@ -40,11 +41,6 @@ echo "GITHUB_REF: $GITHUB_REF"
 echo "DEBUG: file is ${this_file}"
 
 export SLSA_VERIFIER_TESTING="true"
-
-# Make sure the value is exported to slsa-verifier.
-if [[ -n "${COSIGN_REPOSITORY}" ]]; then
-    export COSIGN_REPOSITORY="${COSIGN_REPOSITORY}"
-fi
 
 # Verify provenance authenticity.
 e2e_run_verifier_all_releases "HEAD"


### PR DESCRIPTION
refers: https://github.com/slsa-framework/slsa-verifier/issues/724 and https://github.com/slsa-framework/slsa-github-generator/pull/3099.

Deprecate exporting COSIGN_REPOSITORY for slsa-verifier during container provenance verification when the --provenance-repository is specified.