### PR TITLE
update image to match workflow name for provenance verification

### DIFF
--- a/.github/workflows/e2e.container.schedule.main.provenance-repository.slsa3.yml
+++ b/.github/workflows/e2e.container.schedule.main.provenance-repository.slsa3.yml
@@ -12,7 +12,7 @@ on:
 
 permissions: {}
 
-concurrency: "e2e.container.schedule.main.provenance-registry.slsa3"
+concurrency: "e2e.container.schedule.main.provenance-repository.slsa3"
 
 env:
   GH_TOKEN: ${{ secrets.E2E_CONTAINER_TOKEN }}
@@ -24,7 +24,7 @@ env:
   # NOTE: This pushes a container image to a "namespace" under the
   # slsa-framework Github org.
   # The image name should be of the form: slsa-framework/example-package.<test name>
-  IMAGE_NAME: slsa-framework/example-package.e2e.container.schedule.main.provenance-registry.slsa3
+  IMAGE_NAME: slsa-framework/example-package.e2e.container.schedule.main.provenance-repository.slsa3
   # NOTE: This pushes a provenance image to a "account" under the
   # laurentsimon Dockerhub.
   # The image name should be of the form: laurentsimon/example-package.<test name>


### PR DESCRIPTION
I am leaving behind the dockerhub registry `laurentsimon/example-package.e2e.container.schedule.main.provenance-registry.slsa3` to avoid recreation as per the workflow name!!

Aims to resolve [Error](https://github.com/slsa-framework/example-package/actions/runs/7629461567/job/20783007533#step:6:241) likely caused due to mismatch in workflow file name and image subject in provenance