### PR TITLE
Pass provenance file with provenance_repository input for verifying a…

### DIFF
--- a/.github/workflows/e2e.container.schedule.main.provenance-repository.slsa3.yml
+++ b/.github/workflows/e2e.container.schedule.main.provenance-repository.slsa3.yml
@@ -166,6 +166,7 @@ jobs:
           go-version: "1.20"
       - env:
           CONTAINER: "${{ env.container }}"
+          PROVENANCE: "${{ env.provenance_file }}"
           PROVENANCE_REPOSITORY: ${{ needs.provenance-metadata.outputs.image }}
         run: ./.github/workflows/scripts/e2e.container.default.verify.sh
 


### PR DESCRIPTION
cc: @laurentsimon the test seems to fail at `verifiy_provenance_content()` always seems to execute and expect a provenance file [here](https://github.com/slsa-framework/example-package/actions/runs/7629839993/job/20784264888#step:6:239) and was skipped in favor of the `provenance-repository` input field.

I have added it back along with the provenance-repository but not sure since `provenance` and `provenance-repository` should be mutually exclusive.