### PR TITLE
fix: upgrade bazel for go1.21

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,21 +4,24 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+    sha256 = "6734a719993b1ba4ebe9806e853864395a8d3968ad27f9dd759c196b3eb3abe8",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "29218f8e0cebe583643cbf93cae6f971be8a2484cdcfa1e45057658df8d54002",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.32.0/bazel-gazelle-v0.32.0.tar.gz",
+    integrity = "sha256-MpOL2hbmcABjA1R5Bj2dJMYO2o15/Uc5Vj9Q0zHLMgk=",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz",
+    ],
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("//:deps.bzl", "go_dependencies")
 
 # gazelle:repository_macro deps.bzl%go_dependencies
@@ -26,6 +29,8 @@ go_dependencies()
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.21")
+# According to https://go.dev/blog/toolchain,
+# this minor version toolchain 1.21.6 should still be compatible with major version 1.21
+go_register_toolchains(version = "1.21.6")
 
 gazelle_dependencies()


### PR DESCRIPTION
Followup to #303 to fix slsa-github-generator's e2e tests

- https://github.com/slsa-framework/slsa-github-generator/issues/3130

 ___

bazelbuild/rules_g 0.41.0 claims to support go1.21, but this Issue suggests that it doesn't work
* https://github.com/bazelbuild/rules_go/releases
* https://github.com/bazelbuild/rules_go/issues/3644

Looking at release notes, it's difficult to know for sure which release fixes the issue, but a collaborator claims that it should be fixed after Nov 24, 2023
* https://github.com/bazelbuild/rules_go/releases
* https://github.com/bazelbuild/rules_go/issues/3644#issuecomment-1826085491

bazel-gazelle adds support for go1.21
* https://github.com/bazelbuild/bazel-gazelle/releases/tag/v0.33.0

## Testing

I was able to reproduce the same error on a local machine, without the new changes, and then I can see the build succeed with the new changes

```
➜  example-package git:(4e424362) ✗ ../bazelisk-linux-amd64 build //:hello      
INFO: Repository go_sdk instantiated at:
  /usr/local/google/home/rpetgrave/workspaces/go1.21/example-package/WORKSPACE:29:23: in <toplevel>
  /usr/local/google/home/rpetgrave/.cache/bazel/_bazel_rpetgrave/4c27e051b130bfad03b946c65381161b/external/io_bazel_rules_go/go/private/sdk.bzl:695:28: in go_register_toolchains
  /usr/local/google/home/rpetgrave/.cache/bazel/_bazel_rpetgrave/4c27e051b130bfad03b946c65381161b/external/io_bazel_rules_go/go/private/sdk.bzl:307:25: in go_download_sdk
Repository rule go_download_sdk_rule defined at:
  /usr/local/google/home/rpetgrave/.cache/bazel/_bazel_rpetgrave/4c27e051b130bfad03b946c65381161b/external/io_bazel_rules_go/go/private/sdk.bzl:137:39: in <toplevel>
ERROR: An error occurred during the fetch of repository 'go_sdk':
   Traceback (most recent call last):
        File "/usr/local/google/home/rpetgrave/.cache/bazel/_bazel_rpetgrave/4c27e051b130bfad03b946c65381161b/external/io_bazel_rules_go/go/private/sdk.bzl", line 112, column 17, in _go_download_sdk_impl
                fail("did not find version {} in https://go.dev/dl/?mode=json".format(version))
Error in fail: did not find version 1.21 in https://go.dev/dl/?mode=json
ERROR: /usr/local/google/home/rpetgrave/workspaces/go1.21/example-package/WORKSPACE:29:23: fetching go_download_sdk_rule rule //external:go_sdk: Traceback (most recent call last):
        File "/usr/local/google/home/rpetgrave/.cache/bazel/_bazel_rpetgrave/4c27e051b130bfad03b946c65381161b/external/io_bazel_rules_go/go/private/sdk.bzl", line 112, column 17, in _go_download_sdk_impl
                fail("did not find version {} in https://go.dev/dl/?mode=json".format(version))
Error in fail: did not find version 1.21 in https://go.dev/dl/?mode=json
ERROR: /usr/local/google/home/rpetgrave/workspaces/go1.21/example-package/BUILD:23:10: //:hello depends on @go_sdk//:go_linux_amd64-impl in repository @go_sdk which failed to fetch. no such package '@go_sdk//': did not find version 1.21 in https://go.dev/dl/?mode=json
ERROR: Analysis of target '//:hello' failed; build aborted: Analysis failed
INFO: Elapsed time: 2.324s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (5 packages loaded, 72 targets configured)
```

```
➜  example-package git:(4e424362) ✗ gco -                                      
Previous HEAD position was 4e424362 use go1.21
Switched to branch 'ramonpetgrave64-go1.21'
Your branch is up to date with 'origin/ramonpetgrave64-go1.21'.
```

```
➜  example-package git:(ramonpetgrave64-go1.21) ✗ ../bazelisk-linux-amd64 build //:hello
INFO: Analyzed target //:hello (46 packages loaded, 10013 targets configured).
INFO: Found 1 target...
Target //:hello up-to-date:
  bazel-bin/hello_/hello
INFO: Elapsed time: 6.815s, Critical Path: 0.06s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```
