### PR TITLE
Downgrade upload/download-artifact actions to v3

### DIFF
--- a/.github/workflows/e2e.container-based.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container-based.push.main.default.slsa3.yml
@@ -46,7 +46,7 @@ jobs:
     if: github.event_name == 'push' && github.event.head_commit.message == github.workflow
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.build-outputs-name }}
           path: outputs
@@ -56,7 +56,7 @@ jobs:
           name=$(find outputs/ -type f | head -1)
           cp "${name}" .
           echo "name=$(basename "${name}")" >> "${GITHUB_OUTPUT}"
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}
           path: attestations

--- a/.github/workflows/e2e.container-based.schedule.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container-based.schedule.main.default.slsa3.yml
@@ -33,7 +33,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.build-outputs-name }}
           path: outputs
@@ -43,7 +43,7 @@ jobs:
           name=$(find outputs/ -type f | head -1)
           cp "$name" .
           echo "name=$(basename "$name")" >> "${GITHUB_OUTPUT}"
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}
           path: attestations

--- a/.github/workflows/e2e.container-based.schedule.main.gcp-workload-identity.slsa3.yml
+++ b/.github/workflows/e2e.container-based.schedule.main.gcp-workload-identity.slsa3.yml
@@ -135,7 +135,7 @@ jobs:
     needs: [base, build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.build-outputs-name }}
           path: outputs
@@ -145,7 +145,7 @@ jobs:
           name=$(find outputs/ -type f | head -1)
           cp "${name}" .
           echo "name=$(basename "${name}")" >> "${GITHUB_OUTPUT}"
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}
           path: attestations

--- a/.github/workflows/e2e.container-based.schedule.main.matrix.slsa3.yml
+++ b/.github/workflows/e2e.container-based.schedule.main.matrix.slsa3.yml
@@ -39,7 +39,7 @@ jobs:
           OUTPUTS: ${{ toJSON(needs.build.outputs) }}
         run: echo "${OUTPUTS}"
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.build-outputs-name }}
           path: outputs
@@ -49,7 +49,7 @@ jobs:
           name=$(find outputs/ -type f | head -1)
           cp "$name" .
           echo "name=$(basename "$name")" >> "${GITHUB_OUTPUT}"
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}
           path: attestations

--- a/.github/workflows/e2e.container-based.schedule.main.registry-username-secret.yml
+++ b/.github/workflows/e2e.container-based.schedule.main.registry-username-secret.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [base, build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.build-outputs-name }}
           path: outputs
@@ -84,7 +84,7 @@ jobs:
           name=$(find outputs/ -type f | head -1)
           cp "${name}" .
           echo "name=$(basename "${name}")" >> "${GITHUB_OUTPUT}"
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}
           path: attestations

--- a/.github/workflows/e2e.container-based.schedule.main.registry-username.yml
+++ b/.github/workflows/e2e.container-based.schedule.main.registry-username.yml
@@ -123,7 +123,7 @@ jobs:
     needs: [base, build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.build-outputs-name }}
           path: outputs
@@ -133,7 +133,7 @@ jobs:
           name=$(find outputs/ -type f | head -1)
           cp "${name}" .
           echo "name=$(basename "${name}")" >> "${GITHUB_OUTPUT}"
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}
           path: attestations

--- a/.github/workflows/e2e.container-based.tag.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container-based.tag.main.default.slsa3.yml
@@ -60,7 +60,7 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.build-outputs-name }}
           path: outputs
@@ -70,7 +70,7 @@ jobs:
           name=$(find outputs/ -type f | head -1)
           cp "${name}" .
           echo "name=$(basename "${name}")" >> "${GITHUB_OUTPUT}"
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}
           path: attestations

--- a/.github/workflows/e2e.container-based.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.container-based.workflow_dispatch.main.default.slsa3.yml
@@ -46,7 +46,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.build-outputs-name }}
           path: outputs
@@ -56,7 +56,7 @@ jobs:
           name=$(find outputs/ -type f | head -1)
           cp "${name}" .
           echo "name=$(basename "${name}")" >> "${GITHUB_OUTPUT}"
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.attestations-download-name }}
           path: attestations

--- a/.github/workflows/e2e.delegator-generic.create.main.checkout.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.create.main.checkout.slsa3.yml
@@ -82,7 +82,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms-checkout/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.delegator-generic.create.main.default.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.create.main.default.slsa3.yml
@@ -72,7 +72,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.delegator-generic.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.push.main.default.slsa3.yml
@@ -72,7 +72,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.delegator-generic.release.main.checkout.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.release.main.checkout.slsa3.yml
@@ -84,7 +84,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms-checkout/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.delegator-generic.release.main.default.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.release.main.default.slsa3.yml
@@ -73,7 +73,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.delegator-generic.tag.main.default.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.tag.main.default.slsa3.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.delegator-generic.workflow_dispatch.branch1.checkout.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.workflow_dispatch.branch1.checkout.slsa3.yml
@@ -85,7 +85,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms-checkout/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.delegator-generic.workflow_dispatch.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.workflow_dispatch.branch1.default.slsa3.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.delegator-generic.workflow_dispatch.main.checkout.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.workflow_dispatch.main.checkout.slsa3.yml
@@ -84,7 +84,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms-checkout/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.delegator-generic.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.delegator-generic.workflow_dispatch.main.default.slsa3.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "${{ needs.build.outputs.artifact }}" # NOTE: This is 'my-artifact'.
       - uses: slsa-framework/example-trw/high-perms/actions/download/attestation@v0.0.1

--- a/.github/workflows/e2e.gcb.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.gcb.push.main.default.slsa3.yml
@@ -73,7 +73,7 @@ jobs:
           gcloud artifacts docker images describe "${IMAGE_REGISTRY}/${IMAGE_NAME}@${image_digest}" --show-provenance --format json > provenance.json
           echo "provenance-name=provenance.json" >> "${GITHUB_OUTPUT}"
       - name: Upload provenance
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.describe.outputs.provenance-name }}
           path: ${{ steps.describe.outputs.provenance-name }}
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.provenance-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.gcb.tag.main.annotated-build.slsa3.yml
+++ b/.github/workflows/e2e.gcb.tag.main.annotated-build.slsa3.yml
@@ -73,7 +73,7 @@ jobs:
           gcloud artifacts docker images describe "${IMAGE_REGISTRY}/${IMAGE_NAME}@${image_digest}" --show-provenance --format json > provenance.json
           echo "provenance-name=provenance.json" >> "${GITHUB_OUTPUT}"
       - name: Upload provenance
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.describe.outputs.provenance-name }}
           path: ${{ steps.describe.outputs.provenance-name }}
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.provenance-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.push.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.push.branch1.default.slsa3.yml
@@ -63,7 +63,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -96,10 +96,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.event.head_commit.message == github.workflow
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.push.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.push.main.default.slsa3.yml
@@ -43,7 +43,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >>"${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -77,10 +77,10 @@ jobs:
     if: github.event_name == 'push' && github.event.head_commit.message == github.workflow
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.push.main.upload-tag-name.slsa3.yml
+++ b/.github/workflows/e2e.generic.push.main.upload-tag-name.slsa3.yml
@@ -51,7 +51,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -92,10 +92,10 @@ jobs:
     if: github.event_name == 'push' && github.event.head_commit.message == github.workflow
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.release.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.release.main.default.slsa3.yml
@@ -59,7 +59,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -92,10 +92,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.schedule.main.adversarial-invalidpath.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.adversarial-invalidpath.slsa3.yml
@@ -24,7 +24,7 @@ jobs:
           echo "artifact2" > artifact2
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: artifacts
           if-no-files-found: error

--- a/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.adversarial-invalidsubjects.slsa3.yml
@@ -24,7 +24,7 @@ jobs:
           echo "artifact2" > artifact2
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: artifacts
           if-no-files-found: error

--- a/.github/workflows/e2e.generic.schedule.main.attestation-name.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.attestation-name.slsa3.yml
@@ -31,7 +31,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -65,11 +65,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download binary
-        uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
       - name: Download provenance
-        uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - name: Setup Go

--- a/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.default.slsa3.yml
@@ -31,7 +31,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -64,11 +64,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download binary
-        uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
       - name: Download provenance
-        uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - name: Setup Go

--- a/.github/workflows/e2e.generic.schedule.main.multi-subjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.multi-subjects.slsa3.yml
@@ -25,7 +25,7 @@ jobs:
           echo "artifact3" > artifact3
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: artifacts
           if-no-files-found: error
@@ -62,11 +62,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download binary
-        uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: artifacts
       - name: Download provenance
-        uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - name: Setup Go
@@ -97,7 +97,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download provenance
-        uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - name: Setup Go

--- a/.github/workflows/e2e.generic.schedule.main.multi-uses.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.multi-uses.slsa3.yml
@@ -23,7 +23,7 @@ jobs:
           echo "build 1 artifact 1" > artifact1
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: artifacts1
           if-no-files-found: error
@@ -59,11 +59,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download binary
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: artifacts1
       - name: Download provenance
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance-one.outputs.attestation-name }}
       - name: Setup Go
@@ -87,7 +87,7 @@ jobs:
           echo "build 2 artifact 1" > artifact1
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: artifacts2
           if-no-files-found: error
@@ -126,11 +126,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download binary
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: artifacts2
       - name: Download provenance
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance-two.outputs.attestation-name }}
       - name: Setup Go

--- a/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.branch1.default.slsa3.yml
@@ -61,7 +61,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -94,10 +94,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.tag.main.annotated.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.annotated.slsa3.yml
@@ -49,7 +49,7 @@ jobs:
           echo "build 1 artifact 1" > artifact1
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           path: artifact1
           name: artifact1
@@ -83,10 +83,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: artifact1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.tag.main.assets.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.assets.slsa3.yml
@@ -57,7 +57,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -91,10 +91,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.workflow_dispatch.branch1.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.branch1.default.slsa3.yml
@@ -46,7 +46,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -79,10 +79,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.default.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.default.slsa3.yml
@@ -42,7 +42,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -75,10 +75,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.large-subjects-adversarial-format.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.large-subjects-adversarial-format.slsa3.yml
@@ -37,7 +37,7 @@ jobs:
           echo "hello world" > hello
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.large-subjects-adversarial-sha256.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.large-subjects-adversarial-sha256.slsa3.yml
@@ -37,7 +37,7 @@ jobs:
           echo "hello world" > hello
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.large-subjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.large-subjects.slsa3.yml
@@ -37,7 +37,7 @@ jobs:
           echo "hello world" > hello
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -89,10 +89,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.tagname.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.tagname.slsa3.yml
@@ -38,7 +38,7 @@ jobs:
           echo "build 1 artifact 1" > artifact1
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: artifacts1
           if-no-files-found: error
@@ -78,7 +78,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download binary
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: artifacts1
       - name: Download provenance

--- a/.github/workflows/e2e.generic.workflow_dispatch.main.workflow_inputs.slsa3.yml
+++ b/.github/workflows/e2e.generic.workflow_dispatch.main.workflow_inputs.slsa3.yml
@@ -47,7 +47,7 @@ jobs:
           cp bazel-bin/hello_/hello . # Copy binary from Bazel path to root
           echo "binary-name=hello" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.binary-name }}
           path: ${{ steps.build.outputs.binary-name }}
@@ -80,10 +80,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.attestation-name }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.push.branch1.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.branch1.config-ldflags.slsa3.yml
@@ -99,10 +99,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.event.head_commit.message == github.workflow
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.push.main.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.main.config-ldflags.slsa3.yml
@@ -70,10 +70,10 @@ jobs:
     if: github.event_name == 'push' && github.event.head_commit.message == github.workflow
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.push.main.config-noldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.push.main.config-noldflags.slsa3.yml
@@ -45,10 +45,10 @@ jobs:
     if: github.event_name == 'push' && github.event.head_commit.message == github.workflow
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.release.main.config-ldflags-assets-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-assets-tag.slsa3.yml
@@ -96,10 +96,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.release.main.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-assets.slsa3.yml
@@ -96,10 +96,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.release.main.config-ldflags-noassets.slsa3.yml
+++ b/.github/workflows/e2e.go.release.main.config-ldflags-noassets.slsa3.yml
@@ -83,10 +83,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'release' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.schedule.main.config-ldflags-main-dir.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-ldflags-main-dir.slsa3.yml
@@ -68,10 +68,10 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.schedule.main.config-ldflags-main.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-ldflags-main.slsa3.yml
@@ -60,10 +60,10 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.schedule.main.config-noldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.config-noldflags.slsa3.yml
@@ -32,10 +32,10 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.schedule.main.noldflags-multi-uses.slsa3.yml
+++ b/.github/workflows/e2e.go.schedule.main.noldflags-multi-uses.slsa3.yml
@@ -32,10 +32,10 @@ jobs:
     needs: build-one
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build-one.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build-one.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
@@ -81,10 +81,10 @@ jobs:
     needs: build-two
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build-two.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build-two.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.tag.branch1.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.branch1.config-ldflags-assets.slsa3.yml
@@ -83,10 +83,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-draft-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-draft-tag.slsa3.yml
@@ -92,10 +92,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-prerelease-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-prerelease-tag.slsa3.yml
@@ -98,10 +98,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets-tag.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets-tag.slsa3.yml
@@ -97,10 +97,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-assets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-assets.slsa3.yml
@@ -85,10 +85,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.tag.main.config-ldflags-noassets.slsa3.yml
+++ b/.github/workflows/e2e.go.tag.main.config-ldflags-noassets.slsa3.yml
@@ -84,10 +84,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'push' && github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.branch1.config-ldflags.slsa3.yml
@@ -90,10 +90,10 @@ jobs:
     if: needs.shim.outputs.continue == 'yes' && github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.workflow_dispatch.main.config-noldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.main.config-noldflags.slsa3.yml
@@ -44,10 +44,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.go.workflow_dispatch.main.tagname-noldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.main.tagname-noldflags.slsa3.yml
@@ -46,7 +46,7 @@ jobs:
     needs: [release, build]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
       - name: Download provenance

--- a/.github/workflows/e2e.go.workflow_dispatch.main.workflow_inputs-noldflags.slsa3.yml
+++ b/.github/workflows/e2e.go.workflow_dispatch.main.workflow_inputs-noldflags.slsa3.yml
@@ -52,10 +52,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}
-      - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.build.outputs.go-binary-name }}.intoto.jsonl
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/github-actions-demo.yaml
+++ b/.github/workflows/github-actions-demo.yaml
@@ -11,7 +11,7 @@ jobs:
           artifact_path: bazel-bin/hello_/hello
           output_path: hello.provenance
         continue-on-error: true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           path: |
             bazel-bin/hello_/hello

--- a/.github/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml
+++ b/.github/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml
@@ -76,7 +76,7 @@ jobs:
           cp bazel-bin/hello_/hello "${BINARY_NAME}" # Copy binary from Bazel path to root
           echo "gha_generic_binary-name=$BINARY_NAME" >> "${GITHUB_OUTPUT}"
       - name: Upload binary
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ steps.build.outputs.gha_generic_binary-name }}
           path: ${{ steps.build.outputs.gha_generic_binary-name }}


### PR DESCRIPTION
The v4 versions are incompatibile with v3 and other repos in the org are using v3, so we cannot update only one repo. We need to upgrade everything, everywhere, all at once.

After this PR, we'll use

```
actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
```