### PR TITLE
Fix concurrency for gradle test

### DIFF
--- a/.github/workflows/e2e.gradle.workflow_dispatch.main.project-at-repo-root.slsa3.yml
+++ b/.github/workflows/e2e.gradle.workflow_dispatch.main.project-at-repo-root.slsa3.yml
@@ -11,7 +11,7 @@ on:
 
 permissions: read-all
 
-concurrency: "e2e-gradle-workflow_dispatch-main-default-slsa3"
+concurrency: "e2e-gradle-workflow_dispatch-main-project-repo-at-root-slsa3"
 
 env:
   # TODO(#263): create dedicated token


### PR DESCRIPTION
Fixes the [`concurrency`](https://docs.github.com/en/actions/using-jobs/using-concurrency) for the `.github/workflows/e2e.gradle.workflow_dispatch.main.project-at-repo-root.slsa3.yml` test.

/cc @ramonpetgrave64 