### PR TITLE
fix: caching of THIS_FILE

### DIFF
--- a/.github/workflows/scripts/e2e-utils.sh
+++ b/.github/workflows/scripts/e2e-utils.sh
@@ -19,6 +19,13 @@ e2e_this_file() {
     echo "${THIS_FILE}"
 }
 
+# Cache THIS_FILE in main shell process so that it's applied to subshells.
+# NOTE: This means that the file is always queried once when e2e-utils is
+# sourced.
+if [ "${THIS_FILE}" == "" ]; then
+    e2e_this_file >>/dev/null
+fi
+
 # Gets the name of the "builder" for the e2e test.
 e2e_this_builder() {
     e2e_this_file | cut -d '.' -f2


### PR DESCRIPTION
This PR ensures that `THIS_FILE` is cached. The reason it wasn't previously is that it was cached on first use. This first use is very likely to be in a subshell (e.g. `this_file=$(e2e_this_file)`) and thus only cached `THIS_FILE` in the subshell.

The fix is to call `e2e_this_file` once when `e2e-utils.sh` is sourced to ensure that `THIS_FILE` is set so that it can be passed to subshells.

Fixes #264