### PR TITLE
fix: retries in e2e-bootstrap.sh

### DIFF
--- a/.github/workflows/scripts/e2e-bootstrap.sh
+++ b/.github/workflows/scripts/e2e-bootstrap.sh
@@ -41,54 +41,64 @@ fi
 # bump_npm_package_version bumps the given npm package's patch version,
 # commits it to the local git repo, and outputs the resulting version.
 npm_bump_package_version() {
-    local package_dir
-    local this_event
-    local version
-    package_dir="$(e2e_npm_package_dir)"
-    this_event="$(e2e_this_event)"
+    (
+        # NOTE: Make sure -e is always set for this function.
+        set -euo pipefail
 
-    cd "${package_dir}"
-    # NOTE: npm version patch will not create a git tag if current directory does
-    # not have a .git directory.
-    version="$(npm version patch)"
-    cd - &>/dev/null
+        local package_dir
+        local this_event
+        local version
+        package_dir="$(e2e_npm_package_dir)"
+        this_event="$(e2e_this_event)"
 
-    git add "${package_dir}/package.json" "${package_dir}/package-lock.json" &>/dev/null
+        cd "${package_dir}"
+        # NOTE: npm version patch will not create a git tag if current directory does
+        # not have a .git directory.
+        version="$(npm version patch)"
+        cd - &>/dev/null
 
-    echo "${version}"
+        git add "${package_dir}/package.json" "${package_dir}/package-lock.json" &>/dev/null
+
+        echo "${version}"
+    )
 }
 
 # get_latest_tag outputs the latest release version with the same major version
 # as DEFAULT_VERSION + 1 patch version.
 get_latest_tag() {
-    local latest_tag=$DEFAULT_VERSION
-    local tag
-    local major
-    local default_major
+    (
+        # NOTE: Make sure -e is always set for this function.
+        set -euo pipefail
 
-    default_major=$(version_major "${DEFAULT_VERSION}")
-    if [[ -z "${default_major}" ]]; then
-        echo >&2 "Invalid DEFAULT_VERSION: ${DEFAULT_VERSION}"
-        exit 1
-    fi
+        local latest_tag=$DEFAULT_VERSION
+        local tag
+        local major
+        local default_major
 
-    while read -r line; do
-        tag=$(echo "${line}" | cut -f1)
-        major=$(version_major "$tag")
-        if [ "${major}" == "${default_major}" ]; then
-            if version_gt "${tag}" "${latest_tag}"; then
-                latest_tag="${tag}"
-            fi
+        default_major=$(version_major "${DEFAULT_VERSION}")
+        if [[ -z "${default_major}" ]]; then
+            echo >&2 "Invalid DEFAULT_VERSION: ${DEFAULT_VERSION}"
+            exit 1
         fi
-    done <<<"$(gh api --header 'Accept: application/vnd.github.v3+json' --method GET "/repos/${GITHUB_REPOSITORY}/git/refs/tags" --paginate | jq -r '.[].ref' | cut -d'/' -f3)"
 
-    release_major=$(version_major "$latest_tag")
-    release_minor=$(version_minor "$latest_tag")
-    release_patch=$(version_patch "$latest_tag")
-    new_patch=$((${release_patch:-0} + 1))
-    new_tag="v${release_major:-$default_major}.${release_minor:-0}.$new_patch"
+        while read -r line; do
+            tag=$(echo "${line}" | cut -f1)
+            major=$(version_major "$tag")
+            if [ "${major}" == "${default_major}" ]; then
+                if version_gt "${tag}" "${latest_tag}"; then
+                    latest_tag="${tag}"
+                fi
+            fi
+        done <<<"$(gh api --header 'Accept: application/vnd.github.v3+json' --method GET "/repos/${GITHUB_REPOSITORY}/git/refs/tags" --paginate | jq -r '.[].ref' | cut -d'/' -f3)"
 
-    echo "${new_tag}"
+        release_major=$(version_major "$latest_tag")
+        release_minor=$(version_minor "$latest_tag")
+        release_patch=$(version_patch "$latest_tag")
+        new_patch=$((${release_patch:-0} + 1))
+        new_tag="v${release_major:-$default_major}.${release_minor:-0}.$new_patch"
+
+        echo "${new_tag}"
+    )
 }
 
 this_file=$(e2e_this_file)
@@ -96,112 +106,124 @@ this_branch=$(e2e_this_branch)
 this_builder=$(e2e_this_builder)
 this_event=$(e2e_this_event)
 
-# tag is used later to create a release.
-tag=""
-
 # tag_and_push checks out the repository, updates package versions (if
 # necessary), creates tags (if necessary), creates a new commit and pushes it to
-# the repository.
+# the repository. It then echos the tag that was pushed.
 #
 # We wrap this logic in a function so we can retry it a few times in case there
 # was a concurrent push.
 tag_and_push() {
-    # cleanup in case we are retrying
-    cd "${GITHUB_WORKSPACE}"
-    rm -rf repo_checkout
+    (
+        set -euo pipefail
 
-    # NOTE: We can't simply push from $branch because it is occaisonally reset to
-    # the main branch. We need to maintain the version number in package.json
-    # because you cannot overwrite a version in npmjs.com. Instead we commit to main,
-    # set the tag, reset $branch and push both main and $branch.
-    gh repo clone "${GITHUB_REPOSITORY}" repo_checkout -- -b main
-    cd repo_checkout
+        local tag
 
-    git config --global user.name github-actions
-    git config --global user.email github-actions@github.com
+        # cleanup in case we are retrying
+        cd "${GITHUB_WORKSPACE}" &>/dev/null
+        rm -rf repo_checkout &>/dev/null
 
-    # Set the remote url to authenticate using the token.
-    # NOTE: We must use a PAT here in order to trigger subsequent workflows.
-    # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854
-    # API ref: https://docs.github.com/en/rest/repos/contents#create-a-file.
-    git remote set-url origin "https://github-actions:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        # NOTE: We can't simply push from $branch because it is occaisonally reset to
+        # the main branch. We need to maintain the version number in package.json
+        # because you cannot overwrite a version in npmjs.com. Instead we commit to main,
+        # set the tag, reset $branch and push both main and $branch.
+        gh repo clone "${GITHUB_REPOSITORY}" repo_checkout -- -b main
+        cd repo_checkout &>/dev/null
 
-    if [ "${this_builder}" == "nodejs" ]; then
-        tag="$(npm_bump_package_version)"
-    else
-        if [ "${this_event}" == "tag" ] || [ "${this_event}" == "create" ] || [ "${this_event}" == "release" ]; then
-            tag="$(get_latest_tag)"
-        fi
-    fi
+        git config --global user.name github-actions &>/dev/null
+        git config --global user.email github-actions@github.com &>/dev/null
 
-    # NOTE: push event (tag == push to tag, push == push to branch
-    if [ "${this_event}" == "tag" ] || [ "${this_event}" == "push" ]; then
-        # NOTE: For push events we will make a change to the file below and push it.
-        # This allows us to filter on this file later.
-        file_to_commit=e2e/${this_file}.txt
-        echo -n "$(date --utc)" >"${file_to_commit}"
-        git add "${file_to_commit}"
-    fi
+        # Set the remote url to authenticate using the token.
+        # NOTE: We must use a PAT here in order to trigger subsequent workflows.
+        # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854
+        # API ref: https://docs.github.com/en/rest/repos/contents#create-a-file.
+        git remote set-url origin "https://github-actions:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" &>/dev/null
 
-    # Check if there are changes to commit.
-    if [ "$(git status --porcelain)" != "" ]; then
-        # Commit the changes made so far with a commit message equal to the workflow
-        # name.
-        git commit -am "${GITHUB_WORKFLOW}"
-    fi
-
-    # Create the tag locally.
-    if [ "${tag}" != "" ]; then
-        git tag "${tag}"
-    fi
-
-    # Now we need to push any changes we have made.
-    if [ "${this_branch}" == "main" ]; then
-        if [ "${this_event}" == "tag" ] || [ "${this_event}" == "create" ] || [ "${this_event}" == "release" ]; then
-            # TODO(#213): push tag separately until bug is fixed.
-            # NOTE: If there is a concurrent update to main we want it to fail here
-            # without pushing the tag because we will lose the changes to main.
-            git push origin main
-            git push origin "${tag}"
+        if [ "${this_builder}" == "nodejs" ]; then
+            tag="$(npm_bump_package_version)"
         else
-            git push origin main
+            if [ "${this_event}" == "tag" ] || [ "${this_event}" == "create" ] || [ "${this_event}" == "release" ]; then
+                tag="$(get_latest_tag)"
+            fi
         fi
-    else
-        # Reset branch and push the new version.
-        # NOTE: we haven't pulled the branch locally so we need to create it.
-        git checkout -b "${this_branch}"
-        if [ "${this_event}" == "tag" ] || [ "${this_event}" == "create" ] || [ "${this_event}" == "release" ]; then
-            git push --set-upstream origin "${this_branch}" "${tag}" -f
-        else
-            git push --set-upstream origin "${this_branch}" -f
-        fi
-        git checkout main
 
-        # Update a dummy file to avoid branch mismatches.
-        # See: https://github.com/slsa-framework/example-package/issues/44
-        date >./e2e/dummy
-        git add ./e2e/dummy
-        git commit -m "sync'ing branch1 - $(cat ./e2e/dummy)"
-        git push origin main
-    fi
+        # NOTE: push event "tag" is push to tag, "push" is push to branch
+        if [ "${this_event}" == "tag" ] || [ "${this_event}" == "push" ]; then
+            # NOTE: For push events we will make a change to the file below and push it.
+            # This allows us to filter on this file later.
+            file_to_commit=e2e/${this_file}.txt
+            echo -n "$(date --utc)" >"${file_to_commit}"
+            git add "${file_to_commit}" &>/dev/null
+        fi
+
+        # Check if there are changes to commit.
+        if [ "$(git status --porcelain)" != "" ]; then
+            # Commit the changes made so far with a commit message equal to the workflow
+            # name.
+            git commit -am "${GITHUB_WORKFLOW}" &>/dev/null
+        fi
+
+        # Create the tag locally.
+        if [ "${tag}" != "" ]; then
+            git tag "${tag}" &>/dev/null
+        fi
+
+        # Now we need to push any changes we have made.
+        if [ "${this_branch}" == "main" ]; then
+            if [ "${this_event}" == "tag" ] || [ "${this_event}" == "create" ] || [ "${this_event}" == "release" ]; then
+                # TODO(#213): push tag separately until bug is fixed.
+                # NOTE: If there is a concurrent update to main we want it to fail here
+                # without pushing the tag because we will lose the changes to main.
+                git push origin main &>/dev/null
+                git push origin "${tag}" &>/dev/null
+            else
+                git push origin main &>/dev/null
+            fi
+        else
+            # Reset branch and push the new version.
+            # NOTE: we haven't pulled the branch locally so we need to create it.
+            git checkout -b "${this_branch}"
+            if [ "${this_event}" == "tag" ] || [ "${this_event}" == "create" ] || [ "${this_event}" == "release" ]; then
+                git push --set-upstream origin "${this_branch}" "${tag}" -f &>/dev/null
+            else
+                git push --set-upstream origin "${this_branch}" -f &>/dev/null
+            fi
+            git checkout main &>/dev/null
+
+            # Update a dummy file to avoid branch mismatches.
+            # See: https://github.com/slsa-framework/example-package/issues/44
+            date >./e2e/dummy
+            git add ./e2e/dummy &>/dev/null
+            git commit -m "sync'ing branch1 - $(cat ./e2e/dummy)" &>/dev/null
+            git push origin main &>/dev/null
+        fi
+
+        echo "${tag}"
+    )
 }
 
 # Retry tag_and_push up to 5 times in case there are concurrent pushes to the
 # repo.
 attempt=1
 max_attempts=5
+tag=""
 while [ ${attempt} -le ${max_attempts} ]; do
     echo "Creating new commit and pushing, attempt ${attempt}"
-    # NOTE: using 'if' stops the whole script from failing if tag_and_push
+    # NOTE: Set +e so that the entire script isn't exited if tag_and_push
     # fails.
-    if tag_and_push; then
+    set +e
+    tag=$(tag_and_push)
+    tag_and_push_result="$?"
+    set -e
+    # NOTE: We check $? rather than using `if tag_and_push` because the if
+    # conditional casus bash to always ignore the '-e' bash option.
+    if [[ "${tag_and_push_result}" == "0" ]]; then
         break
     fi
 
     # Add a bit of jitter to space out retries.
     jitter=$((RANDOM % 6)) # Random number 0 - 5
     sleep $((10 + jitter))
-    attempt=$((attempt + 1))
+    ((attempt += 1))
 done
 
 # If this is a test for a release event, create the release.


### PR DESCRIPTION
This fixes retries in `e2e-bootstrap.sh`. The reason for previous failure to retry was due to the fact that bash ignores the `-e` option when executing a function inside an `if` conditional.
See: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

Instead we need to set `+e` before executing the function and set `-e` inside a sub-shell inside the `tag_and_push` function. This causes the the function to terminate early if any command fails, but not terminate the overall script when the function fails.

We also need to call the function directly and test the `$?` return code rather than using an `if` conditional so that the `-e` is respected.

Fixes #283