### PR TITLE
use provenance-name, not attestation-name

### DIFF
--- a/.github/workflows/e2e.generic.schedule.main.adversarial-invalidpath.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.adversarial-invalidpath.slsa3.yml
@@ -51,7 +51,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@main
     with:
       base64-subjects: "${{ needs.build.outputs.digests }}"
-      attestation-name: ../some/file.intoto.jsonl
+      provenance-name: ../some/file.intoto.jsonl
       compile-generator: true
 
   if-failed-build:

--- a/.github/workflows/e2e.generic.schedule.main.multi-uses.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.multi-uses.slsa3.yml
@@ -50,7 +50,7 @@ jobs:
     with:
       base64-subjects: "${{ needs.build-one.outputs.digests }}"
       compile-generator: true
-      attestation-name: "attestation1.intoto.jsonl"
+      provenance-name: "attestation1.intoto.jsonl"
 
   verify-one:
     runs-on: ubuntu-latest
@@ -117,7 +117,7 @@ jobs:
     with:
       base64-subjects: "${{ needs.build-two.outputs.digests }}"
       compile-generator: true
-      attestation-name: "attestation2.intoto.jsonl"
+      provenance-name: "attestation2.intoto.jsonl"
 
   verify-two:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.generic.schedule.main.provenance-name.slsa3.yml
+++ b/.github/workflows/e2e.generic.schedule.main.provenance-name.slsa3.yml
@@ -55,7 +55,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@main
     with:
       base64-subjects: "${{ needs.build.outputs.digest }}"
-      attestation-name: "custom-name.intoto.jsonl"
+      provenance-name: "custom-name.intoto.jsonl"
       compile-generator: true
 
   verify:
@@ -76,12 +76,12 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.21"
-      - name: Verify attestation name
+      - name: Verify provenance name
         env:
           PROVENANCE: ${{ needs.provenance.outputs.provenance-name }}
         run: |
           source "./.github/workflows/scripts/e2e-assert.sh"
-          e2e_assert_eq "${PROVENANCE}" "custom-name.intoto.jsonl" "incorrect attestation-name"
+          e2e_assert_eq "${PROVENANCE}" "custom-name.intoto.jsonl" "incorrect provenance-name"
       - name: Verify provenance
         env:
           BINARY: ${{ needs.build.outputs.binary-name }}


### PR DESCRIPTION
Fixes this e2e test to use the provenance-name input, not the deprecated attestation-name.

https://github.com/slsa-framework/example-package/actions/runs/8469402503/workflow

https://github.com/slsa-framework/slsa-github-generator/issues/3471