### PR TITLE
Update e2e.nodejs.push.main.custom_publish.slsa3.yml

### DIFF
--- a/.github/workflows/e2e.nodejs.push.main.custom_publish.slsa3.yml
+++ b/.github/workflows/e2e.nodejs.push.main.custom_publish.slsa3.yml
@@ -74,11 +74,6 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
 
-      - run: |
-          # Install npm >9.7.0 which includes support for --provenance-file.
-          # This installs locally in the temp directory.
-          npm install -g npm@^9.7.0
-
       - name: Download tarball
         uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-package-download@main
         with:


### PR DESCRIPTION
Attempt to fix the publish e2e. 
https://github.com/slsa-framework/example-package/actions/runs/8700699961/job/23861438652
https://github.com/slsa-framework/slsa-github-generator/issues/3494#issuecomment-2058296965

Just use the default npm cli version
https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry