### PR TITLE
fix: update the GCB builder ID

### DIFF
--- a/.github/workflows/scripts/e2e-verify.common.sh
+++ b/.github/workflows/scripts/e2e-verify.common.sh
@@ -214,7 +214,7 @@ get_builder_id() {
         builder_id="https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/heads/main"
         ;;
     "gcb")
-        builder_id="https://cloudbuild.googleapis.com/GoogleHostedWorker@v0.3"
+        builder_id="https://cloudbuild.googleapis.com/GoogleHostedWorker"
         ;;
     "container")
         builder_id="https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/heads/main"


### PR DESCRIPTION
Addresses https://github.com/slsa-framework/slsa-github-generator/issues/3002#issuecomment-2060304866

```
...
FAILED: SLSA verification failed: builderID does not match provenance: expected version 'v0.3', got ''
```

The GCB Builder ID for newer provenances now does not include the tag `@v0.3` under the `inTotoSlsaProvenanceV1 `.
 - https://cloud.google.com/build/docs/securing-builds/view-build-provenance

We'll have to verify without the tag. Not including the tag is still compatible with slsa-verifier for older provenances.

### Testing

Tested in a GCP cloud console

A helper script to debug, checking against the age of the build (index), and the tag the check.
Similar to our [e2e test ](https://github.com/slsa-framework/example-package/blob/2643b5de5feed274ccdfdf8b855adbeb673e15a7/.github/workflows/e2e.gcb.tag.main.annotated-build.slsa3.yml#L63-L74)

```
rpetgrave@cloudshell:~ (slsa-tooling)$ do_test () {
    idx=$1
    tag=$2

    BUILDER_ID="https://cloudbuild.googleapis.com/GoogleHostedWorker${tag}"
    IMAGE_REGISTRY="us-west2-docker.pkg.dev"
    IMAGE_NAME="slsa-tooling/example-package-repo/e2e-gcb-tag-main-annotated-slsa3"
    build_id=$(gcloud builds list --filter "results.images.name=${IMAGE_REGISTRY}/${IMAGE_NAME}" --region=us-west2 --project slsa-tooling --limit=20 --format=json | jq -r '.[env.idx | tonumber].id')
    image_digest=$(gcloud builds describe "${build_id}" --project=slsa-tooling --region=us-west2 --format="value(results.images[0].digest)")
    gcloud artifacts docker images describe "${IMAGE_REGISTRY}/${IMAGE_NAME}@${image_digest}" --show-provenance --format json > provenance.json
    IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}@${image_digest}"
    SOURCE="https://github.com/slsa-framework/example-package"

    slsa-verifier verify-image "$IMAGE" \
    --provenance-path provenance.json \
    --source-uri "$SOURCE" \
    --builder-id="$BUILDER_ID"
}
```

Using the tag fails for recent builds up until the builds from December and older.

```
rpetgrave@cloudshell:~ (slsa-tooling)$ do_test 0 @v0.3 # fail
WARNING: Insecure SLSA_VERIFIER_TESTING is enabled.
Verification succeeded with key "global-pae-google-hosted-worker_1"
FAILED: SLSA verification failed: builderID does not match provenance: expected version 'v0.3', got ''

rpetgrave@cloudshell:~ (slsa-tooling)$ do_test 8 @v0.3 # fail
WARNING: Insecure SLSA_VERIFIER_TESTING is enabled.
Verification succeeded with key "global-pae-google-hosted-worker_1"
FAILED: SLSA verification failed: builderID does not match provenance: expected version 'v0.3', got ''

rpetgrave@cloudshell:~ (slsa-tooling)$ do_test 9 @v0.3 # pass
WARNING: Insecure SLSA_VERIFIER_TESTING is enabled.
Verification succeeded with key "global-pae-provenanceSigner_1"
PASSED: Verified SLSA provenance
```

Not using the tag passes for all past and current provenances.

```
rpetgrave@cloudshell:~ (slsa-tooling)$ do_test 0 "" # pass
WARNING: Insecure SLSA_VERIFIER_TESTING is enabled.
Verification succeeded with key "global-pae-google-hosted-worker_1"
PASSED: Verified SLSA provenance

rpetgrave@cloudshell:~ (slsa-tooling)$ do_test 8 "" # pass
WARNING: Insecure SLSA_VERIFIER_TESTING is enabled.
Verification succeeded with key "global-pae-google-hosted-worker_1"
PASSED: Verified SLSA provenance

rpetgrave@cloudshell:~ (slsa-tooling)$ do_test 9 "" # pass
WARNING: Insecure SLSA_VERIFIER_TESTING is enabled.
Verification succeeded with key "global-pae-provenanceSigner_1"
PASSED: Verified SLSA provenance

rpetgrave@cloudshell:~ (slsa-tooling)$ do_test 15 "" # pass
WARNING: Insecure SLSA_VERIFIER_TESTING is enabled.
Verification succeeded with key "global-pae-provenanceSigner_1"
PASSED: Verified SLSA provenance
```

