### PR TITLE
fix: goreleaser deprecated option

### DIFF
--- a/.github/workflows/e2e.generic.tag.main.goreleaser-assets-multi-subjects.slsa3.yml
+++ b/.github/workflows/e2e.generic.tag.main.goreleaser-assets-multi-subjects.slsa3.yml
@@ -64,7 +64,7 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
           workdir: ./e2e/goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
changes `--rm-dist` to `--clean`

 - https://goreleaser.com/deprecations/#-rm-dist