### PR TITLE
fix: slsa-verifier > v2.6.0

### DIFF
--- a/.github/workflows/scripts/e2e.nodejs.default.verify.sh
+++ b/.github/workflows/scripts/e2e.nodejs.default.verify.sh
@@ -113,7 +113,7 @@ verify_provenance_content
 
 verify_dist_tag
 
-# Verify provenance authenticity with min version at release v2.5.1
-# Due to the breaking change below, we only need to verify starting at v2.51
-# https://github.com/slsa-framework/slsa-github-generator/issues/3350
-e2e_run_verifier_all_releases "v2.5.1"
+# Verify provenance authenticity with min version at release v2.6.0
+# Due to the breaking change below, we only need to verify starting at v2.6.0
+# https://github.com/slsa-framework/slsa-verifier/issues/757#issuecomment-2627508086
+e2e_run_verifier_all_releases "v2.6.0"


### PR DESCRIPTION
fixes npmjs e2e due to a stale key.

Re: https://github.com/slsa-framework/slsa-github-generator/issues/4078#issuecomment-2625208892

- https://github.com/slsa-framework/slsa-verifier/issues/757#issuecomment-2627508086