### PR TITLE
add dsseEnvelope to the jq path

### DIFF
--- a/.github/workflows/scripts/e2e.go.default.verify.sh
+++ b/.github/workflows/scripts/e2e.go.default.verify.sh
@@ -34,7 +34,7 @@ fi
 
 # Function used to verify the content of the provenance.
 verify_provenance_content() {
-    attestation=$(jq -r '.payload' <"$PROVENANCE" | base64 -d)
+    attestation=$(jq -r '.dsseEnvelope.payload' <"$PROVENANCE" | base64 -d)
     #TRIGGER=$(echo "$THIS_FILE" | cut -d '.' -f3)
     #BRANCH=$(echo "$THIS_FILE" | cut -d '.' -f4)
     this_file=$(e2e_this_file)


### PR DESCRIPTION
The provenance is now inside a `.dsseEnvelope` field in the json.

## Testing

The script is able to parse the provenance for a workflow run with this PR's branch.

https://github.com/slsa-framework/example-package/actions/runs/13335633961/job/37250233689#step:6:133