### PR TITLE
fix: use github.token in release workflow

### DIFF
--- a/.github/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml
+++ b/.github/workflows/verifier-e2e.all.workflow_dispatch.main.all.slsa3.yml
@@ -15,7 +15,8 @@ on:
 permissions: read-all
 
 env:
-  GH_TOKEN: ${{ secrets.E2E_CONTAINER_TOKEN }}
+  # GH_TOKEN: ${{ secrets.E2E_CONTAINER_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IMAGE_REGISTRY: ghcr.io
   # NOTE: This pushes a container image to a "package" under the
   # slsa-framework GitHub org.


### PR DESCRIPTION
The release workflow uses a github token as a secret. That token may have expored since last year, so we'll switch to using the workflow's built-in github.token for auth.

https://github.com/slsa-framework/example-package/actions/runs/13526102724/job/37799444267#step:3:16

```
https://github.com/slsa-framework/example-package/actions/runs/13526102724/job/37799444267#step:3:16
```

## Testing

Ran the workflow against this branch and all jobs passed, uploading the assets.

https://github.com/slsa-framework/example-package/actions/runs/13527009542

