### PR TITLE
build: comment out typecheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,7 +59,7 @@ linters:
     - staticcheck
     - stylecheck
     - thelper
-    - typecheck
+    # - typecheck
     - unconvert
     - unused
     - whitespace


### PR DESCRIPTION
The typecheck linter is temporarily disabled due to https://github.com/slsa-framework/example-package/actions/runs/16688765805/job/47243009043, https://github.com/slsa-framework/example-package/actions/runs/16688820536/job/47243131208, https://github.com/golangci/golangci-lint/issues/4482.