### PR TITLE
Fix: Pin golang base image by hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5 as builder
+FROM golang:1.24.5@sha256:ef5b4be1f94b36c90385abd9b6b4f201723ae28e71acacb76d00687333c17282 as builder
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
Pins the golang base image in the Dockerfile to a specific sha256 digest to ensure reproducible builds.