### PR TITLE
chore(ci): declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/e2e.vsa.gcp.gke.yml
+++ b/.github/workflows/e2e.vsa.gcp.gke.yml
@@ -10,6 +10,9 @@ env:
   GH_TOKEN: ${{ secrets.E2E_GENERIC_TOKEN }}
   ISSUE_REPOSITORY: slsa-framework/slsa-verifier
 
+permissions:
+  contents: read
+
 jobs:
   verify-attestations:
     strategy:

--- a/.github/workflows/github-actions-demo.yaml
+++ b/.github/workflows/github-actions-demo.yaml
@@ -1,5 +1,9 @@
 name: Build using github-actions-demo
 on: [workflow_dispatch]
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on:

- `e2e.vsa.gcp.gke.yml` (e2e slsa-verifier dry-run; uses a separate PAT via `secrets.E2E_GENERIC_TOKEN` for any issue interactions, so the default `GITHUB_TOKEN` itself only needs to fetch code)
- `github-actions-demo.yaml` (manual build + upload-artifact; no GitHub API writes)

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from caller workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default.

YAML validated locally with `yaml.safe_load` on each touched file.